### PR TITLE
feat(phase7): activate weekly rank recompute scheduler and alerts

### DIFF
--- a/.github/workflows/rank-recompute-weekly.yml
+++ b/.github/workflows/rank-recompute-weekly.yml
@@ -1,0 +1,117 @@
+name: rank-recompute-weekly
+
+on:
+  schedule:
+    - cron: "15 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      timeframe:
+        description: "Leaderboard timeframe to recompute"
+        required: false
+        default: "weekly"
+        type: choice
+        options:
+          - weekly
+          - daily
+          - monthly
+          - all_time
+      limit:
+        description: "Maximum boards to scan"
+        required: false
+        default: "200"
+        type: number
+      determinismProbeCount:
+        description: "How many rebuilt boards to probe for repeated-run determinism"
+        required: false
+        default: "3"
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  recompute:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: rank-recompute-weekly
+      cancel-in-progress: false
+    env:
+      DEFAULT_TIMEFRAME: weekly
+      DEFAULT_LIMIT: "200"
+      DEFAULT_DETERMINISM_PROBE_COUNT: "3"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve parameters
+        id: params
+        shell: bash
+        run: |
+          timeframe="${{ github.event.inputs.timeframe }}"
+          limit="${{ github.event.inputs.limit }}"
+          probe="${{ github.event.inputs.determinismProbeCount }}"
+
+          if [ -z "$timeframe" ]; then timeframe="$DEFAULT_TIMEFRAME"; fi
+          if [ -z "$limit" ]; then limit="$DEFAULT_LIMIT"; fi
+          if [ -z "$probe" ]; then probe="$DEFAULT_DETERMINISM_PROBE_COUNT"; fi
+
+          echo "timeframe=$timeframe" >> "$GITHUB_OUTPUT"
+          echo "limit=$limit" >> "$GITHUB_OUTPUT"
+          echo "probe=$probe" >> "$GITHUB_OUTPUT"
+
+      - name: Validate required secrets
+        shell: bash
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ -z "${SUPABASE_URL:-}" ] || [ -z "${SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+            echo "Missing required repo secrets SUPABASE_URL and/or SUPABASE_SERVICE_ROLE_KEY." >&2
+            exit 1
+          fi
+
+      - name: Run weekly recompute
+        shell: bash
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          node scripts/run-rank-recompute-weekly.mjs \
+            --timeframe "${{ steps.params.outputs.timeframe }}" \
+            --limit "${{ steps.params.outputs.limit }}" \
+            --determinism-probe-count "${{ steps.params.outputs.probe }}" \
+            --output-file rank-recompute-report.json
+
+      - name: Upload recompute report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rank-recompute-report-${{ github.run_id }}
+          path: rank-recompute-report.json
+
+      - name: Create ops alert issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = `[OPS] Rank recompute failed (${new Date().toISOString().slice(0, 10)})`;
+            const body = [
+              "Rank recompute scheduler reported a failure.",
+              `- Workflow run: ${runUrl}`,
+              `- Trigger: ${context.eventName}`,
+              `- Commit: ${context.sha}`,
+              "",
+              "Inspect the `rank-recompute-report` workflow artifact for detailed diagnostics."
+            ].join("\n");
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: ["high-priority", "phase-7"]
+            });

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -23,7 +23,7 @@
 6. Connect integration monitoring UI to `createPhase6IntegrationMonitorFlow`.
 7. Wire production provider credentials and scheduler cadence for `provider_webhook_ingest` + `sync_dispatcher`.
 8. Connect rank/trials UI to `createPhase7RankTrialsFlow` + `CompetitionService`.
-9. Enable weekly rank recompute scheduler calling `rank_recompute_weekly`.
+9. Validate weekly rank recompute scheduler (`.github/workflows/rank-recompute-weekly.yml`) and alert routing.
 10. Run privacy workflows (`submit_privacy_request`) and staff handling pipeline (`transition_privacy_request_status`).
 
 ## Feature flag activation policy

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -23,8 +23,9 @@
 8. Configure recurring runs for integration jobs:
    - schedule `sync_dispatcher` for frequent execution
    - route provider callbacks into `provider_webhook_ingest`
-9. Configure scheduler for weekly ranks:
-   - call `rank_recompute_weekly` edge function
+9. Validate active rank scheduler:
+   - verify `.github/workflows/rank-recompute-weekly.yml` succeeds with project secrets
+   - tune `determinismProbeCount`/`limit` after first two production runs
 10. Configure scheduler for privacy queue:
    - call `privacy_request_processor` with triage/overdue/export limits
 11. Operationalize compliance runbook in staff workflows:

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -11,6 +11,7 @@
 - Phase 6 runtime: Apple/Garmin integration pipeline (mobile integration service + webhook ingest + sync dispatcher + cursor persistence)
 - Phase 6 monitoring runtime: admin integration health + sync failure monitor flow for gym staff
 - Phase 7 runtime: rank ladder + trials service layer with deterministic leaderboard recompute and challenge progress RPCs
+- Phase 7 ops follow-up: weekly rank recompute scheduler workflow + deterministic repeat probes + failure issue alerts
 - Phase 8 runtime (slice 1): privacy request lifecycle services/flows + queue processor for triage and SLA breach marking
 - Phase 8 runtime (slice 2): immutable policy/consent registry + audited consent RPCs + workout re-consent gate
 - Phase 8 runtime (slice 3): export package generation with signed URL delivery + retry-safe queue processing
@@ -28,5 +29,6 @@
 - Mobile and admin feature-complete UI screen implementation (React Native + Next runtime wiring)
 - Supabase auth wiring and protected client routes
 - Direct provider API polling implementations for production credentials (Apple/Garmin providers currently webhook-first runtime)
-- Scheduled job orchestration (cron cadence + alerting) and production observability dashboards
+- Scheduled job orchestration still pending for `sync_dispatcher` and `privacy_request_processor`
+- Production observability dashboards
 - KPI instrumentation and analytics ingestion

--- a/docs/phase7-runtime.md
+++ b/docs/phase7-runtime.md
@@ -6,6 +6,7 @@ Phase 7 runtime now includes the Rank Ladder + Trials execution layer:
 - Atomic challenge RPCs for join/leave/progress submissions
 - Deterministic leaderboard rebuild logic with anti-cheat filters
 - Weekly recompute edge function with per-board failure reporting
+- Scheduled weekly recompute workflow with failure alerts and deterministic repeat probes
 
 ## Mobile entrypoints
 
@@ -34,8 +35,17 @@ Core methods:
 
 - `supabase/functions/rank_recompute_weekly/index.ts`
   - defaults to weekly boards
-  - supports optional body filters (`timeframe`, `leaderboardIds`, `limit`)
-  - returns `rebuiltCount` and `failures` for deterministic job monitoring
+  - supports optional body filters (`timeframe`, `leaderboardIds`, `limit`, `determinismProbeCount`)
+  - returns `rebuiltCount`, `failures`, and `determinismFailures` for deterministic job monitoring
+
+## Scheduler and monitoring
+
+- `.github/workflows/rank-recompute-weekly.yml`
+  - weekly auto-run (`04:15 UTC` Monday) + manual dispatch
+  - calls `scripts/run-rank-recompute-weekly.mjs`
+  - uploads run artifact with full diagnostics
+  - opens a high-priority phase-7 issue if recompute fails
+- `docs/rank-recompute-ops.md` documents secret setup, runbook, and expected success signals
 
 ## DB migration hooks
 

--- a/docs/rank-recompute-ops.md
+++ b/docs/rank-recompute-ops.md
@@ -1,0 +1,56 @@
+# Rank Recompute Scheduler Ops
+
+## Objective
+
+Run `rank_recompute_weekly` automatically each week, fail fast on rebuild errors, and verify deterministic ordering on repeated runs.
+
+## Scheduler
+
+- Workflow: `.github/workflows/rank-recompute-weekly.yml`
+- Cadence: every Monday at `04:15 UTC`
+- Manual trigger: GitHub Actions -> `rank-recompute-weekly` -> `Run workflow`
+
+## Required GitHub repository secrets
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+Without both secrets, the workflow fails at the validation step.
+
+## Runtime checks performed each run
+
+1. Invoke edge function: `POST /functions/v1/rank_recompute_weekly`
+2. Rebuild active boards for the selected timeframe
+3. Run deterministic repeat probe on `determinismProbeCount` rebuilt boards:
+   - snapshot leaderboard entries hash
+   - rebuild same board again
+   - snapshot hash again
+   - mismatch -> run marked failed
+
+## Monitoring output
+
+- Step summary in GitHub Actions run logs
+- Artifact: `rank-recompute-report-<run_id>` containing full JSON diagnostics
+- Determinism diagnostics included as `determinismFailures`
+
+## Alert path
+
+If the workflow fails, it opens a GitHub issue labeled `high-priority` + `phase-7` with run URL and investigation pointer.
+
+## Local/manual run
+
+```bash
+SUPABASE_URL="https://<project-ref>.supabase.co" \
+SUPABASE_SERVICE_ROLE_KEY="<service-role-key>" \
+node scripts/run-rank-recompute-weekly.mjs \
+  --timeframe weekly \
+  --limit 200 \
+  --determinism-probe-count 3 \
+  --output-file rank-recompute-report.json
+```
+
+## Expected success conditions
+
+- `failedCount = 0`
+- `determinismMismatchCount = 0`
+- `httpStatus = 200`

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -77,13 +77,16 @@
 58. `submit_challenge_progress` enforces per-type anti-cheat delta thresholds.
 59. `rebuild_leaderboard_scope` tie ordering is deterministic (`score desc`, stable user tie-break).
 60. `rank_recompute_weekly` returns deterministic failure diagnostics when one board rebuild fails.
+61. `rank_recompute_weekly` deterministic probe reports `determinismMismatchCount = 0` for stable inputs.
 
 ## Rollout Gates
 
-61. Pavia pilot readiness checklist is fully completed before invite activation.
-62. Weekly KPI board is updated on cadence with explicit gate outcome (`Pass`, `Conditional`, `Fail`).
-63. Incident rollback playbook includes ordered flag rollback actions and communication SLA.
-64. US+EU expansion criteria are tracked and require two consecutive passing weekly reviews.
+62. Pavia pilot readiness checklist is fully completed before invite activation.
+63. Weekly KPI board is updated on cadence with explicit gate outcome (`Pass`, `Conditional`, `Fail`).
+64. Incident rollback playbook includes ordered flag rollback actions and communication SLA.
+65. US+EU expansion criteria are tracked and require two consecutive passing weekly reviews.
+66. Weekly `rank-recompute-weekly` scheduler run produces artifact report and exits non-zero on recompute failure.
+67. Failed scheduler run creates a high-priority phase-7 alert issue with workflow run URL.
 
 ## Performance targets for pilot
 

--- a/scripts/run-rank-recompute-weekly.mjs
+++ b/scripts/run-rank-recompute-weekly.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import { appendFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+
+const ALLOWED_TIMEFRAMES = new Set(["daily", "weekly", "monthly", "all_time"]);
+
+function parseArgs(argv) {
+  const parsed = {
+    timeframe: "weekly",
+    limit: 200,
+    determinismProbeCount: 3,
+    outputFile: ""
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+
+    if (token === "--timeframe" && value) {
+      parsed.timeframe = value;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--limit" && value) {
+      parsed.limit = Number(value);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--determinism-probe-count" && value) {
+      parsed.determinismProbeCount = Number(value);
+      index += 1;
+      continue;
+    }
+
+    if (token === "--output-file" && value) {
+      parsed.outputFile = value;
+      index += 1;
+      continue;
+    }
+  }
+
+  return parsed;
+}
+
+function asPositiveInt(value, fallback) {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.trunc(value));
+}
+
+async function writeStepSummary(path, lines) {
+  if (!path) {
+    return;
+  }
+
+  await appendFile(path, `${lines.join("\n")}\n`, "utf8");
+}
+
+async function main() {
+  const config = parseArgs(process.argv.slice(2));
+  const timeframe = config.timeframe;
+
+  if (!ALLOWED_TIMEFRAMES.has(timeframe)) {
+    throw new Error(`Invalid timeframe: ${timeframe}`);
+  }
+
+  const limit = asPositiveInt(config.limit, 200);
+  const determinismProbeCount = Math.max(0, Math.trunc(config.determinismProbeCount));
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required.");
+  }
+
+  const endpoint = `${supabaseUrl.replace(/\/$/, "")}/functions/v1/rank_recompute_weekly`;
+  const requestBody = {
+    timeframe,
+    limit,
+    determinismProbeCount
+  };
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${serviceRoleKey}`,
+      apikey: serviceRoleKey,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(requestBody)
+  });
+
+  const rawText = await response.text();
+  let parsed;
+
+  try {
+    parsed = rawText ? JSON.parse(rawText) : {};
+  } catch (_error) {
+    parsed = { parseError: true, rawText };
+  }
+
+  const failedCount = Number(parsed?.failedCount ?? 0);
+  const determinismMismatchCount = Number(
+    parsed?.determinismMismatchCount ??
+      (Array.isArray(parsed?.determinismFailures) ? parsed.determinismFailures.length : 0)
+  );
+
+  const status = !response.ok || failedCount > 0 || determinismMismatchCount > 0 ? "failed" : "succeeded";
+
+  const summary = {
+    status,
+    requestedAt: new Date().toISOString(),
+    endpoint,
+    requestBody,
+    httpStatus: response.status,
+    scannedCount: Number(parsed?.scannedCount ?? 0),
+    rebuiltCount: Number(parsed?.rebuiltCount ?? 0),
+    failedCount,
+    determinismProbeCount: Number(parsed?.determinismProbeCount ?? determinismProbeCount),
+    determinismMismatchCount,
+    response: parsed
+  };
+
+  if (config.outputFile) {
+    await writeFile(config.outputFile, `${JSON.stringify(summary, null, 2)}\n`, "utf8");
+  }
+
+  await writeStepSummary(process.env.GITHUB_STEP_SUMMARY, [
+    "## Rank Recompute Weekly",
+    `- Status: **${summary.status.toUpperCase()}**`,
+    `- HTTP status: \`${summary.httpStatus}\``,
+    `- Timeframe: \`${timeframe}\``,
+    `- Scanned boards: \`${summary.scannedCount}\``,
+    `- Rebuilt boards: \`${summary.rebuiltCount}\``,
+    `- Rebuild failures: \`${summary.failedCount}\``,
+    `- Determinism probes: \`${summary.determinismProbeCount}\``,
+    `- Determinism mismatches: \`${summary.determinismMismatchCount}\``
+  ]);
+
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (!response.ok) {
+    throw new Error(`rank_recompute_weekly returned HTTP ${response.status}`);
+  }
+
+  if (failedCount > 0) {
+    throw new Error(`rank_recompute_weekly reported ${failedCount} rebuild failures.`);
+  }
+
+  if (determinismMismatchCount > 0) {
+    throw new Error(`Determinism probe detected ${determinismMismatchCount} mismatch(es).`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -2,7 +2,7 @@
 
 - `provider_webhook_ingest`: stores provider callbacks with idempotency fields, provider flag gating, and sync job fan-out for Apple/Garmin
 - `sync_dispatcher`: claims queued sync jobs, processes webhook-linked imports, persists cursor state, and handles retry/backoff safely
-- `rank_recompute_weekly`: recomputes active boards (weekly by default) and returns per-board failure diagnostics
+- `rank_recompute_weekly`: recomputes active boards (weekly by default), supports deterministic repeat probes, and returns per-board failure diagnostics
 - `privacy_request_processor`: triages submitted requests, marks overdue SLA breaches, generates signed privacy export packages, and executes delete/anonymize jobs with legal-hold checks
 - `audit_event_ingest`: writes append-only audit records (integrity chain enforced in DB)
 - `incident_notifier`: claims incident notification jobs and runs provider-agnostic email/webhook stub notifiers (drill-safe by default)

--- a/supabase/functions/rank_recompute_weekly/index.ts
+++ b/supabase/functions/rank_recompute_weekly/index.ts
@@ -7,6 +7,7 @@ interface RecomputeInput {
   timeframe?: RecomputeTimeframe;
   leaderboardIds?: string[];
   limit?: number;
+  determinismProbeCount?: number;
 }
 
 interface LeaderboardRow {
@@ -14,6 +15,64 @@ interface LeaderboardRow {
   timeframe: RecomputeTimeframe;
   starts_at: string;
   ends_at: string;
+}
+
+interface LeaderboardEntryRow {
+  user_id: string;
+  rank: number;
+  score: number | string | null;
+  details: Record<string, unknown> | null;
+}
+
+interface SnapshotResult {
+  hash: string;
+  rowCount: number;
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function normalizeScore(value: number | string | null): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "number") {
+    return value.toFixed(3);
+  }
+
+  return value;
+}
+
+async function snapshotLeaderboard(
+  supabase: ReturnType<typeof serviceClient>,
+  leaderboardId: string
+): Promise<SnapshotResult> {
+  const { data, error } = await supabase
+    .from("leaderboard_entries")
+    .select("user_id,rank,score,details")
+    .eq("leaderboard_id", leaderboardId)
+    .order("rank", { ascending: true })
+    .order("user_id", { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = ((data as LeaderboardEntryRow[]) ?? []).map((row) => ({
+    userId: row.user_id,
+    rank: Number(row.rank),
+    score: normalizeScore(row.score),
+    details: row.details ?? {}
+  }));
+
+  const hash = await sha256Hex(JSON.stringify(rows));
+  return { hash, rowCount: rows.length };
 }
 
 Deno.serve(async (request) => {
@@ -29,6 +88,7 @@ Deno.serve(async (request) => {
     }
 
     const limit = Math.min(Math.max(body.limit ?? 100, 1), 500);
+    const requestedDeterminismProbeCount = Math.min(Math.max(body.determinismProbeCount ?? 0, 0), 25);
     const supabase = serviceClient();
     const nowIso = new Date().toISOString();
     let query = supabase
@@ -68,13 +128,70 @@ Deno.serve(async (request) => {
       }
     }
 
+    const determinismFailures: Array<{
+      leaderboardId: string;
+      reason: string;
+      error?: string;
+      firstHash?: string;
+      secondHash?: string;
+      firstRowCount?: number;
+      secondRowCount?: number;
+    }> = [];
+    const probeIds = rebuilt.slice(0, requestedDeterminismProbeCount);
+    let determinismProbeCount = 0;
+
+    for (const leaderboardId of probeIds) {
+      try {
+        const firstSnapshot = await snapshotLeaderboard(supabase, leaderboardId);
+        const { error: probeError } = await supabase.rpc("rebuild_leaderboard_scope", {
+          p_leaderboard_id: leaderboardId
+        });
+
+        if (probeError) {
+          determinismFailures.push({
+            leaderboardId,
+            reason: "rebuild_failed_during_probe",
+            error: probeError.message
+          });
+          continue;
+        }
+
+        const secondSnapshot = await snapshotLeaderboard(supabase, leaderboardId);
+        determinismProbeCount += 1;
+
+        if (firstSnapshot.hash !== secondSnapshot.hash) {
+          determinismFailures.push({
+            leaderboardId,
+            reason: "non_deterministic_ordering",
+            firstHash: firstSnapshot.hash,
+            secondHash: secondSnapshot.hash,
+            firstRowCount: firstSnapshot.rowCount,
+            secondRowCount: secondSnapshot.rowCount
+          });
+        }
+      } catch (probeError) {
+        determinismFailures.push({
+          leaderboardId,
+          reason: "probe_error",
+          error: probeError instanceof Error ? probeError.message : String(probeError)
+        });
+      }
+    }
+
+    failed.sort((left, right) => left.leaderboardId.localeCompare(right.leaderboardId));
+    determinismFailures.sort((left, right) => left.leaderboardId.localeCompare(right.leaderboardId));
+
     return jsonResponse({
       timeframe,
       scannedCount: (boards ?? []).length,
       rebuiltCount: rebuilt.length,
       failedCount: failed.length,
+      determinismProbeCount,
+      requestedDeterminismProbeCount,
+      determinismMismatchCount: determinismFailures.length,
       leaderboardIds: rebuilt,
-      failures: failed
+      failures: failed,
+      determinismFailures
     });
   } catch (error) {
     return jsonResponse({ error: String(error) }, 500);


### PR DESCRIPTION
## Summary
- add scheduled GitHub Actions workflow to run `rank_recompute_weekly` every Monday with manual dispatch support
- add `scripts/run-rank-recompute-weekly.mjs` runner that gates failures on rebuild errors and determinism mismatches
- extend `rank_recompute_weekly` with optional deterministic repeat probes (`determinismProbeCount`) and detailed diagnostics
- add operations docs and update roadmap/status/next-steps references for Phase 7 scheduler activation

## Validation
- `node --check scripts/run-rank-recompute-weekly.mjs`
- `node scripts/run-rank-recompute-weekly.mjs --timeframe weekly --limit 10 --determinism-probe-count 1` (expected failure without required env secrets)

## Notes
- Full `pnpm` workspace checks are blocked in this shell because host Node is `v16.15.0` and `pnpm` is unavailable.

Closes #22
