### PR TITLE
feat(phase2-mobile): wire onboarding UI flow to auth/profile/consent/gym services

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Operational features are controlled by flags in `public.feature_flags`.
 ## Phase 2 Runtime
 
 - Mobile onboarding + guild hall flows: `apps/mobile/src/services`, `apps/mobile/src/flows`
+- UI onboarding controller for screen wiring + recoverable errors: `apps/mobile/src/flows/phase2-onboarding-ui.ts`
 - Admin staff ops services + flows: `apps/admin/src/services`, `apps/admin/src/flows`
 - Usage notes: `docs/phase2-runtime.md`
+- Screen wiring guide: `docs/phase2-mobile-onboarding-ui-wiring.md`
 
 ## Phase 3 Runtime
 

--- a/apps/mobile/src/app.tsx
+++ b/apps/mobile/src/app.tsx
@@ -25,8 +25,17 @@ export function mobileAppScaffold() {
     defaultEnabledFlags,
     phase2: {
       flow: "auth -> profile -> consents -> gym role -> guild hall",
+      screenFlow: "welcome -> auth -> profile -> consents -> gym -> review -> guild hall",
       checklist: [...phase2OnboardingChecklist],
       guildHallChecklist: [...guildHallChecklist],
+      recoverableErrors: [
+        "ONBOARDING_VALIDATION_FAILED",
+        "AUTH_SIGNIN_FAILED",
+        "PROFILE_UPSERT_FAILED",
+        "BASELINE_CONSENT_REQUIRED",
+        "GYM_JOIN_FAILED",
+        "ONBOARDING_HOME_GYM_NOT_PERSISTED"
+      ],
       rpcEndpoints: [
         "log_workout_atomic",
         "join_waitlist",

--- a/apps/mobile/src/flows/phase2-onboarding-ui.ts
+++ b/apps/mobile/src/flows/phase2-onboarding-ui.ts
@@ -1,0 +1,423 @@
+import type { CreateGymInput, UpsertProfileInput } from "@kruxt/types";
+import { translateLegalText } from "@kruxt/types";
+
+import {
+  createMobileSupabaseClient,
+  KruxtAppError,
+  Phase2OnboardingService,
+  type BaselineConsentInput,
+  type Phase2OnboardingInput,
+  type Phase2OnboardingResult
+} from "../services";
+import { phase2OnboardingChecklistKeys } from "./phase2-onboarding";
+
+export type OnboardingUiStep = "auth" | "profile" | "consents" | "gym" | "review";
+
+export interface OnboardingScreenSpec {
+  step: OnboardingUiStep;
+  title: string;
+  subtitle: string;
+  primaryActionLabel: string;
+}
+
+export interface OnboardingAuthDraft {
+  mode: Phase2OnboardingInput["mode"];
+  email: string;
+  password: string;
+}
+
+export interface OnboardingProfileDraft {
+  username: string;
+  displayName: string;
+  avatarUrl?: string;
+  bio?: string;
+  locale?: string;
+  preferredUnits?: "metric" | "imperial";
+}
+
+export type OnboardingGymDraft =
+  | {
+      mode: "skip";
+    }
+  | {
+      mode: "create";
+      createGym: CreateGymInput;
+      setAsHomeGym?: boolean;
+    }
+  | {
+      mode: "join";
+      gymId: string;
+      setAsHomeGym?: boolean;
+    };
+
+export interface OnboardingUiDraft {
+  auth: OnboardingAuthDraft;
+  profile: OnboardingProfileDraft;
+  consents: BaselineConsentInput;
+  gym: OnboardingGymDraft;
+}
+
+export interface OnboardingFieldError {
+  field: string;
+  message: string;
+}
+
+export interface OnboardingUiError {
+  code: string;
+  step: OnboardingUiStep;
+  message: string;
+  recoverable: boolean;
+  fieldErrors: OnboardingFieldError[];
+}
+
+export interface OnboardingUiSuccess {
+  ok: true;
+  result: Phase2OnboardingResult;
+  nextRoute: "guild_hall";
+}
+
+export interface OnboardingUiFailure {
+  ok: false;
+  error: OnboardingUiError;
+}
+
+export type OnboardingUiSubmitResult = OnboardingUiSuccess | OnboardingUiFailure;
+
+const PHASE2_ONBOARDING_SCREEN_SPECS: readonly OnboardingScreenSpec[] = [
+  {
+    step: "auth",
+    title: "Claim your profile",
+    subtitle: "Proof counts. Start with your account.",
+    primaryActionLabel: "Continue"
+  },
+  {
+    step: "profile",
+    title: "Set your identity",
+    subtitle: "Choose how your guild sees your progress.",
+    primaryActionLabel: "Save profile"
+  },
+  {
+    step: "consents",
+    title: "Accept the rules",
+    subtitle: "Terms, privacy, and health-data consent are required.",
+    primaryActionLabel: "Accept and continue"
+  },
+  {
+    step: "gym",
+    title: "Join a guild",
+    subtitle: "Create a gym or request access to an existing one.",
+    primaryActionLabel: "Continue"
+  },
+  {
+    step: "review",
+    title: "Finish onboarding",
+    subtitle: "Post the proof.",
+    primaryActionLabel: "Enter Guild Hall"
+  }
+] as const;
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function inferStepFromField(field: string): OnboardingUiStep {
+  if (field.startsWith("auth.")) {
+    return "auth";
+  }
+
+  if (field.startsWith("profile.")) {
+    return "profile";
+  }
+
+  if (field.startsWith("consents.")) {
+    return "consents";
+  }
+
+  if (field.startsWith("gym.")) {
+    return "gym";
+  }
+
+  return "review";
+}
+
+function sanitizeProfileDraft(draft: OnboardingProfileDraft): Partial<UpsertProfileInput> {
+  return {
+    username: draft.username.trim(),
+    displayName: draft.displayName.trim(),
+    avatarUrl: draft.avatarUrl?.trim() || undefined,
+    bio: draft.bio?.trim() || undefined,
+    locale: draft.locale?.trim() || undefined,
+    preferredUnits: draft.preferredUnits
+  };
+}
+
+function toGymPreference(gym: OnboardingGymDraft): Phase2OnboardingInput["gymPreference"] {
+  if (gym.mode === "create") {
+    return {
+      createGym: gym.createGym,
+      setAsHomeGym: gym.setAsHomeGym ?? true
+    };
+  }
+
+  if (gym.mode === "join") {
+    return {
+      joinGymId: gym.gymId,
+      setAsHomeGym: gym.setAsHomeGym ?? true
+    };
+  }
+
+  return undefined;
+}
+
+function toServiceInput(draft: OnboardingUiDraft): Phase2OnboardingInput {
+  const profile = sanitizeProfileDraft(draft.profile);
+
+  return {
+    mode: draft.auth.mode,
+    credentials: {
+      email: draft.auth.email.trim(),
+      password: draft.auth.password
+    },
+    profile,
+    baselineConsents: {
+      ...draft.consents,
+      locale: profile.locale ?? draft.consents.locale
+    },
+    gymPreference: toGymPreference(draft.gym)
+  };
+}
+
+function validateDraft(draft: OnboardingUiDraft): OnboardingFieldError[] {
+  const errors: OnboardingFieldError[] = [];
+
+  if (!emailPattern.test(draft.auth.email.trim())) {
+    errors.push({
+      field: "auth.email",
+      message: "Enter a valid email address."
+    });
+  }
+
+  const minPasswordLength = draft.auth.mode === "signup" ? 8 : 1;
+  if (draft.auth.password.length < minPasswordLength) {
+    errors.push({
+      field: "auth.password",
+      message:
+        draft.auth.mode === "signup"
+          ? "Password must be at least 8 characters."
+          : "Password is required."
+    });
+  }
+
+  if (!draft.profile.displayName.trim()) {
+    errors.push({
+      field: "profile.displayName",
+      message: "Display name is required."
+    });
+  }
+
+  if (!draft.profile.username.trim()) {
+    errors.push({
+      field: "profile.username",
+      message: "Username is required."
+    });
+  }
+
+  if (!draft.consents.acceptTerms) {
+    errors.push({
+      field: "consents.acceptTerms",
+      message: "You must accept terms to continue."
+    });
+  }
+
+  if (!draft.consents.acceptPrivacy) {
+    errors.push({
+      field: "consents.acceptPrivacy",
+      message: "You must accept privacy policy to continue."
+    });
+  }
+
+  if (!draft.consents.acceptHealthData) {
+    errors.push({
+      field: "consents.acceptHealthData",
+      message: "You must accept health-data processing to continue."
+    });
+  }
+
+  if (draft.gym.mode === "create") {
+    if (!draft.gym.createGym.name.trim()) {
+      errors.push({
+        field: "gym.create.name",
+        message: "Gym name is required."
+      });
+    }
+
+    if (!draft.gym.createGym.slug.trim()) {
+      errors.push({
+        field: "gym.create.slug",
+        message: "Gym slug is required."
+      });
+    }
+  }
+
+  if (draft.gym.mode === "join" && !draft.gym.gymId.trim()) {
+    errors.push({
+      field: "gym.join.gymId",
+      message: "Select a gym to request membership."
+    });
+  }
+
+  return errors;
+}
+
+function mapErrorToStep(code: string): OnboardingUiStep {
+  if (
+    [
+      "ONBOARDING_EMAIL_INVALID",
+      "ONBOARDING_PASSWORD_INVALID",
+      "AUTH_SIGNIN_FAILED",
+      "AUTH_SIGNUP_FAILED",
+      "AUTH_GET_USER_FAILED",
+      "AUTH_REQUIRED"
+    ].includes(code)
+  ) {
+    return "auth";
+  }
+
+  if (
+    [
+      "PROFILE_READ_FAILED",
+      "PROFILE_UPSERT_FAILED",
+      "PROFILE_USERNAME_COLLISION",
+      "PROFILE_NOT_FOUND"
+    ].includes(code)
+  ) {
+    return "profile";
+  }
+
+  if (
+    [
+      "BASELINE_CONSENT_REQUIRED",
+      "CONSENT_RECORD_FAILED",
+      "CONSENT_GAPS_READ_FAILED",
+      "CONSENT_GATE_CHECK_FAILED",
+      "ONBOARDING_CONSENT_CAPTURE_INCOMPLETE",
+      "RECONSENT_REQUIRED",
+      "POLICY_BASELINE_MISSING"
+    ].includes(code)
+  ) {
+    return "consents";
+  }
+
+  if (
+    [
+      "GYM_CREATE_FAILED",
+      "GYM_JOIN_FAILED",
+      "GYM_SLUG_INVALID",
+      "GYM_SLUG_CONFLICT",
+      "PROFILE_HOME_GYM_UPDATE_FAILED",
+      "ONBOARDING_HOME_GYM_NOT_PERSISTED"
+    ].includes(code)
+  ) {
+    return "gym";
+  }
+
+  return "review";
+}
+
+function mapErrorMessage(code: string, fallback: string): string {
+  if (code === "AUTH_SIGNIN_FAILED") {
+    return "Sign in failed. Verify email and password, then retry.";
+  }
+
+  if (code === "AUTH_SIGNUP_FAILED") {
+    return "Sign up failed. Retry in a moment.";
+  }
+
+  if (code === "PROFILE_USERNAME_COLLISION") {
+    return "That username is unavailable. Try another username.";
+  }
+
+  if (code === "BASELINE_CONSENT_REQUIRED") {
+    return translateLegalText("legal.error.baseline_consent_required");
+  }
+
+  if (code === "RECONSENT_REQUIRED") {
+    return translateLegalText("legal.error.reconsent_required_action");
+  }
+
+  if (code === "POLICY_BASELINE_MISSING") {
+    return "Legal policy records are not available right now. Try again shortly.";
+  }
+
+  if (code === "GYM_JOIN_FAILED") {
+    return "Membership request failed. Retry after refreshing the gym list.";
+  }
+
+  if (code === "ONBOARDING_HOME_GYM_NOT_PERSISTED") {
+    return "Home gym was not saved. Retry this step.";
+  }
+
+  return fallback;
+}
+
+function mapRuntimeError(error: unknown): OnboardingUiError {
+  const appError =
+    error instanceof KruxtAppError
+      ? error
+      : new KruxtAppError("ONBOARDING_SUBMIT_FAILED", "Unable to complete onboarding.", error);
+
+  const step = mapErrorToStep(appError.code);
+  const message = mapErrorMessage(appError.code, appError.message);
+  const recoverable = appError.code !== "POLICY_BASELINE_MISSING";
+
+  return {
+    code: appError.code,
+    step,
+    message,
+    recoverable,
+    fieldErrors: []
+  };
+}
+
+export function createPhase2OnboardingUiFlow(options: { locale?: string | null } = {}) {
+  const supabase = createMobileSupabaseClient();
+  const onboarding = new Phase2OnboardingService(supabase);
+  const checklist = phase2OnboardingChecklistKeys.map((key) =>
+    translateLegalText(key, { locale: options.locale })
+  );
+
+  return {
+    checklist,
+    checklistKeys: phase2OnboardingChecklistKeys,
+    screens: [...PHASE2_ONBOARDING_SCREEN_SPECS],
+    validate: (draft: OnboardingUiDraft): OnboardingFieldError[] => validateDraft(draft),
+    submit: async (draft: OnboardingUiDraft): Promise<OnboardingUiSubmitResult> => {
+      const fieldErrors = validateDraft(draft);
+
+      if (fieldErrors.length > 0) {
+        return {
+          ok: false,
+          error: {
+            code: "ONBOARDING_VALIDATION_FAILED",
+            step: inferStepFromField(fieldErrors[0]?.field ?? "review"),
+            message: "Review highlighted fields and retry.",
+            recoverable: true,
+            fieldErrors
+          }
+        };
+      }
+
+      try {
+        const result = await onboarding.run(toServiceInput(draft));
+        return {
+          ok: true,
+          result,
+          nextRoute: "guild_hall"
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapRuntimeError(error)
+        };
+      }
+    }
+  };
+}

--- a/apps/mobile/src/index.ts
+++ b/apps/mobile/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./app";
 export * from "./services";
 export * from "./flows/phase2-onboarding";
+export * from "./flows/phase2-onboarding-ui";
 export * from "./flows/guild-hall";
 export * from "./flows/phase3-workout-logging";
 export * from "./flows/phase4-social-feed";

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -16,7 +16,7 @@
 ## Ordered build sequence
 
 1. Apply DB migration and seed data in Supabase project.
-2. Connect auth flow in mobile/admin to `profiles` creation, consent capture, guild hall load, and staff ops snapshot.
+2. Connect auth flow in mobile/admin to `profiles` creation, consent capture, guild hall load, and staff ops snapshot (`createPhase2OnboardingUiFlow` for mobile screens).
 3. Implement workout logger UI and call `log_workout_atomic` RPC (see `createPhase3WorkoutLoggingFlow`).
 4. Build feed UI from `createPhase4SocialFeedFlow` (`feed_events` + joined `workouts` + `social_interactions`).
 5. Connect admin UI screens to `createPhase5B2BOpsFlow` and `B2BOpsService`.

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -5,6 +5,7 @@
 - Phase 0: monorepo scaffold, CI skeleton, env template, shared packages, scripts
 - Phase 1: complete Supabase schema v2 migration with RLS, RPCs, triggers, seed flags
 - Phase 2 runtime: mobile onboarding + guild hall flows + admin staff ops/triage services
+- Phase 2 mobile UI wiring: onboarding screen controller with recoverable step-level errors and submit routing
 - Phase 3 runtime: workout logging flow with proof-feed and progress verification
 - Phase 4 runtime: social graph/feed ranking/notification service layer for mobile
 - Phase 5 runtime: admin B2B ops service layer for classes, waitlist, waivers, contracts, check-ins, and billing telemetry

--- a/docs/phase2-mobile-onboarding-ui-wiring.md
+++ b/docs/phase2-mobile-onboarding-ui-wiring.md
@@ -1,0 +1,38 @@
+# Phase 2 Mobile Onboarding UI Wiring
+
+Use `createPhase2OnboardingUiFlow` as the single controller for onboarding screens.
+
+## Screen sequence
+
+1. `auth`
+2. `profile`
+3. `consents`
+4. `gym`
+5. `review`
+6. route to `guild_hall`
+
+The controller exposes `screens` metadata so mobile UI can render titles/subtitles/action labels consistently.
+
+## Runtime contract
+
+- `validate(draft)`
+  - returns field errors with step-aware field paths (for inline form error rendering)
+- `submit(draft)`
+  - returns `{ ok: true, result, nextRoute: "guild_hall" }` on success
+  - returns `{ ok: false, error }` on failure
+  - errors include: `step`, `code`, `message`, `recoverable`, `fieldErrors`
+
+## Recoverable UX behavior
+
+- If `error.recoverable = true`, keep user on `error.step` and show `error.message`.
+- If `fieldErrors` exists, map field paths (for example `auth.email`, `consents.acceptTerms`) to inline form states.
+- If `recoverable = false`, show blocking fallback with retry option and support contact.
+
+## Guaranteed post-checks in service
+
+`Phase2OnboardingService.run` now enforces:
+
+- required baseline consents are persisted (`terms`, `privacy`, `health_data_processing`)
+- requested home gym is actually persisted on `profiles.home_gym_id`
+
+If either check fails, onboarding returns a recoverable failure to the UI controller.

--- a/docs/phase2-runtime.md
+++ b/docs/phase2-runtime.md
@@ -10,11 +10,14 @@ This repository now includes executable TypeScript service modules for:
 
 - `apps/mobile/src/services/phase2-onboarding-service.ts`
 - `apps/mobile/src/flows/phase2-onboarding.ts`
+- `apps/mobile/src/flows/phase2-onboarding-ui.ts`
 - `apps/mobile/src/flows/guild-hall.ts`
 
 Core methods:
 
 - `Phase2OnboardingService.run(...)`
+- `createPhase2OnboardingUiFlow(...).validate(...)`
+- `createPhase2OnboardingUiFlow(...).submit(...)`
 - `ProfileService.ensureProfile(...)`
 - `PolicyService.captureBaselineConsents(...)`
 - `GymService.createGymWithLeaderMembership(...)`
@@ -50,6 +53,11 @@ Supporting DB RPCs for strict-RLS admin reads:
 ## Wiring expectations
 
 - Mobile app should call onboarding flow immediately after auth submit.
+- Mobile onboarding screens should use `createPhase2OnboardingUiFlow` for:
+  - per-step validation (`auth/profile/consents/gym/review`)
+  - recoverable user-readable errors with step targeting
+  - end-to-end submit that returns `nextRoute = guild_hall`
 - Mobile app can load guild hall state after onboarding/auth via `createGuildHallFlow`.
 - Admin routes should enforce `requireGymStaff` before any management action.
 - All actions rely on existing RLS policies in the migration file.
+- Detailed screen wiring reference: `docs/phase2-mobile-onboarding-ui-wiring.md`.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -15,78 +15,81 @@
 8. PR detection marks `workout_sets.is_pr` and inserts one `pr_verified` feed event per workout.
 9. Feed ranking v1 remains deterministic for a fixed event snapshot and scoring inputs.
 10. Push token registration/deactivation is limited to token owner by RLS.
+11. `createPhase2OnboardingUiFlow.validate` returns step-targeted field errors (`auth/profile/consents/gym`).
+12. `Phase2OnboardingService.run` rejects when required baseline consent persistence cannot be confirmed.
+13. `Phase2OnboardingService.run` rejects when requested home gym is not persisted to profile.
 
 ## B2B Operations
 
-11. Waitlist promotion books first pending user by position.
-12. Check-in logs preserve result and source channel.
-13. Waiver and contract acceptances are immutable evidence records.
+14. Waitlist promotion books first pending user by position.
+15. Check-in logs preserve result and source channel.
+16. Waiver and contract acceptances are immutable evidence records.
 
 ## Integrations
 
-14. Duplicate webhook events remain idempotent.
-15. Sync job retries update status and preserve cursor integrity.
-16. Imported activities dedupe by `(user_id, provider, external_activity_id)`.
-17. `device_sync_cursors` updates only by service role; users can read only their own cursors.
+17. Duplicate webhook events remain idempotent.
+18. Sync job retries update status and preserve cursor integrity.
+19. Imported activities dedupe by `(user_id, provider, external_activity_id)`.
+20. `device_sync_cursors` updates only by service role; users can read only their own cursors.
 
 ## Compliance
 
-18. Consent records retain policy version evidence.
-19. Privacy request transitions are valid (`submitted -> triaged -> in_progress -> fulfilled/rejected`).
-20. Audit log rows are append-only.
-21. Admin consent/privacy RPCs only return members linked to the requested gym.
-22. Consent rows are immutable (`update/delete` attempts fail for all roles).
-23. Policy version rows are immutable after insert (new versions publish as new rows only).
-24. `record_user_consent` always writes audit + outbox events with policy bindings.
-25. `list_missing_required_consents` returns deterministic gaps for missing/revoked/reconsent-required states.
-26. `user_has_required_consents` blocks protected actions when re-consent is required.
-27. `queue_privacy_export_jobs` queues only open `access/export` requests and is idempotent under retries.
-28. `claim_privacy_export_jobs` respects retry schedule and does not double-claim rows under concurrency.
-29. Export payload excludes secret credentials (no encrypted device tokens present in output).
-30. `complete_privacy_export_job` writes expiring response link metadata and emits `privacy.export_ready`.
-31. `fail_privacy_export_job` schedules retries and hard-fails with request rejection at max retry count.
-32. `queue_privacy_delete_jobs` queues only open `delete` requests and remains idempotent under retries.
-33. `has_active_legal_hold` blocks delete fulfillment for held users, with terminal fail when forced final.
-34. `apply_user_anonymization` is idempotent and removes/scrubs targeted rows without FK breakage.
-35. `complete_privacy_delete_job` marks request fulfilled and stores anonymization summary payload.
-36. `fail_privacy_delete_job` retries with backoff and rejects the request at final failure.
-37. Audit log rows are immutable and reject `update/delete` with append-only guardrails.
-38. `audit_log_integrity_drift` detects sequence/hash mismatches after forced tamper simulation.
-39. Security-relevant `event_outbox` inserts produce `security.event_outbox` audit entries.
-40. Staff/user direct inserts into `audit_logs` are denied; service pipeline inserts remain valid.
-41. `create_security_incident` enforces gym-staff or service access and writes action/outbox/audit records.
-42. `transition_security_incident_status` enforces valid lifecycle transitions and stage timestamps.
-43. `admin_list_security_incidents` exposes deadline countdown and breached flags to operators.
-44. `queue_incident_escalation_notifications` creates drill/live jobs with auditable escalation actions.
-45. `incident_notifier` drill mode processes jobs without external sends while preserving completion metadata.
-46. `fail_incident_notification_job` retries with backoff and marks terminal failures deterministically.
-47. `normalize_legal_locale` + `legal_locale_fallback_chain` always produce deterministic fallback (`requested -> en-US`).
-48. `resolve_legal_copy` and `list_legal_copy_bundle` return localized legal strings with stable fallback rank.
-49. Legal checklists in mobile/admin Phase 8 flows are key-driven (no hardcoded legal copy in flow definitions).
-50. Legal timestamp formatting returns locale/timezone-correct output for EU and US timezone inputs.
-51. `admin_get_privacy_ops_metrics` returns deterministic open/overdue counters and bounded measurement window.
-52. Phase 8 compliance queue filters (`status/type/SLA/user`) return stable subsets for identical inputs.
-53. SLA badge derivation in admin flow is deterministic at boundary conditions (`breached`, `at_risk`, `on_track`, `no_due_date`).
-54. Compliance runbook mapping exists and matches admin queue actions (`load`, `transition`, `metrics`).
-55. Admin compliance view exposes active policy versions with effective dates for operator verification.
+21. Consent records retain policy version evidence.
+22. Privacy request transitions are valid (`submitted -> triaged -> in_progress -> fulfilled/rejected`).
+23. Audit log rows are append-only.
+24. Admin consent/privacy RPCs only return members linked to the requested gym.
+25. Consent rows are immutable (`update/delete` attempts fail for all roles).
+26. Policy version rows are immutable after insert (new versions publish as new rows only).
+27. `record_user_consent` always writes audit + outbox events with policy bindings.
+28. `list_missing_required_consents` returns deterministic gaps for missing/revoked/reconsent-required states.
+29. `user_has_required_consents` blocks protected actions when re-consent is required.
+30. `queue_privacy_export_jobs` queues only open `access/export` requests and is idempotent under retries.
+31. `claim_privacy_export_jobs` respects retry schedule and does not double-claim rows under concurrency.
+32. Export payload excludes secret credentials (no encrypted device tokens present in output).
+33. `complete_privacy_export_job` writes expiring response link metadata and emits `privacy.export_ready`.
+34. `fail_privacy_export_job` schedules retries and hard-fails with request rejection at max retry count.
+35. `queue_privacy_delete_jobs` queues only open `delete` requests and remains idempotent under retries.
+36. `has_active_legal_hold` blocks delete fulfillment for held users, with terminal fail when forced final.
+37. `apply_user_anonymization` is idempotent and removes/scrubs targeted rows without FK breakage.
+38. `complete_privacy_delete_job` marks request fulfilled and stores anonymization summary payload.
+39. `fail_privacy_delete_job` retries with backoff and rejects the request at final failure.
+40. Audit log rows are immutable and reject `update/delete` with append-only guardrails.
+41. `audit_log_integrity_drift` detects sequence/hash mismatches after forced tamper simulation.
+42. Security-relevant `event_outbox` inserts produce `security.event_outbox` audit entries.
+43. Staff/user direct inserts into `audit_logs` are denied; service pipeline inserts remain valid.
+44. `create_security_incident` enforces gym-staff or service access and writes action/outbox/audit records.
+45. `transition_security_incident_status` enforces valid lifecycle transitions and stage timestamps.
+46. `admin_list_security_incidents` exposes deadline countdown and breached flags to operators.
+47. `queue_incident_escalation_notifications` creates drill/live jobs with auditable escalation actions.
+48. `incident_notifier` drill mode processes jobs without external sends while preserving completion metadata.
+49. `fail_incident_notification_job` retries with backoff and marks terminal failures deterministically.
+50. `normalize_legal_locale` + `legal_locale_fallback_chain` always produce deterministic fallback (`requested -> en-US`).
+51. `resolve_legal_copy` and `list_legal_copy_bundle` return localized legal strings with stable fallback rank.
+52. Legal checklists in mobile/admin Phase 8 flows are key-driven (no hardcoded legal copy in flow definitions).
+53. Legal timestamp formatting returns locale/timezone-correct output for EU and US timezone inputs.
+54. `admin_get_privacy_ops_metrics` returns deterministic open/overdue counters and bounded measurement window.
+55. Phase 8 compliance queue filters (`status/type/SLA/user`) return stable subsets for identical inputs.
+56. SLA badge derivation in admin flow is deterministic at boundary conditions (`breached`, `at_risk`, `on_track`, `no_due_date`).
+57. Compliance runbook mapping exists and matches admin queue actions (`load`, `transition`, `metrics`).
+58. Admin compliance view exposes active policy versions with effective dates for operator verification.
 
 ## Rank + Trials
 
-56. `join_challenge` allows visible, non-ended challenges only.
-57. `leave_challenge` rejects completed participants and only removes caller-owned rows.
-58. `submit_challenge_progress` enforces per-type anti-cheat delta thresholds.
-59. `rebuild_leaderboard_scope` tie ordering is deterministic (`score desc`, stable user tie-break).
-60. `rank_recompute_weekly` returns deterministic failure diagnostics when one board rebuild fails.
-61. `rank_recompute_weekly` deterministic probe reports `determinismMismatchCount = 0` for stable inputs.
+59. `join_challenge` allows visible, non-ended challenges only.
+60. `leave_challenge` rejects completed participants and only removes caller-owned rows.
+61. `submit_challenge_progress` enforces per-type anti-cheat delta thresholds.
+62. `rebuild_leaderboard_scope` tie ordering is deterministic (`score desc`, stable user tie-break).
+63. `rank_recompute_weekly` returns deterministic failure diagnostics when one board rebuild fails.
+64. `rank_recompute_weekly` deterministic probe reports `determinismMismatchCount = 0` for stable inputs.
 
 ## Rollout Gates
 
-62. Pavia pilot readiness checklist is fully completed before invite activation.
-63. Weekly KPI board is updated on cadence with explicit gate outcome (`Pass`, `Conditional`, `Fail`).
-64. Incident rollback playbook includes ordered flag rollback actions and communication SLA.
-65. US+EU expansion criteria are tracked and require two consecutive passing weekly reviews.
-66. Weekly `rank-recompute-weekly` scheduler run produces artifact report and exits non-zero on recompute failure.
-67. Failed scheduler run creates a high-priority phase-7 alert issue with workflow run URL.
+65. Pavia pilot readiness checklist is fully completed before invite activation.
+66. Weekly KPI board is updated on cadence with explicit gate outcome (`Pass`, `Conditional`, `Fail`).
+67. Incident rollback playbook includes ordered flag rollback actions and communication SLA.
+68. US+EU expansion criteria are tracked and require two consecutive passing weekly reviews.
+69. Weekly `rank-recompute-weekly` scheduler run produces artifact report and exits non-zero on recompute failure.
+70. Failed scheduler run creates a high-priority phase-7 alert issue with workflow run URL.
 
 ## Performance targets for pilot
 


### PR DESCRIPTION
## Summary
- add `createPhase2OnboardingUiFlow` to wire onboarding screens (`auth -> profile -> consents -> gym -> review`) with a single submit contract
- add step-aware client validation and recoverable, user-readable runtime error mapping for onboarding UX
- harden `Phase2OnboardingService.run` with strict post-checks for baseline consent persistence and home-gym persistence
- expose the UI flow in mobile package exports and document implementation + wiring runbook

## Validation
- `apps/mobile/node_modules/.bin/tsc --noEmit -p apps/mobile/tsconfig.json`
- `bash packages/db/tests/run_smoke.sh`

## Acceptance coverage
- End-to-end onboarding submit now returns structured success (`nextRoute = guild_hall`) or recoverable step-targeted failure
- Consent capture is enforced and verified (`assertRequiredConsents` + required consent presence check)
- Home gym persistence is enforced and verified before returning success
- Error states are mapped to readable copy and specific onboarding steps

Closes #3
