### PR TITLE
feat(phase2-admin): wire staff console UI to membership queue actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ Operational features are controlled by flags in `public.feature_flags`.
 - Mobile onboarding + guild hall flows: `apps/mobile/src/services`, `apps/mobile/src/flows`
 - UI onboarding controller for screen wiring + recoverable errors: `apps/mobile/src/flows/phase2-onboarding-ui.ts`
 - Admin staff ops services + flows: `apps/admin/src/services`, `apps/admin/src/flows`
+- Admin console UI controller for staff queue/actions: `apps/admin/src/flows/phase2-staff-console-ui.ts`
 - Usage notes: `docs/phase2-runtime.md`
 - Screen wiring guide: `docs/phase2-mobile-onboarding-ui-wiring.md`
+- Admin wiring guide: `docs/phase2-admin-console-ui-wiring.md`
 
 ## Phase 3 Runtime
 

--- a/apps/admin/src/app/page.ts
+++ b/apps/admin/src/app/page.ts
@@ -1,4 +1,4 @@
-import { phase2StaffOpsChecklist } from "../flows/phase2-staff-ops";
+import { phase2StaffConsoleUiChecklist } from "../flows/phase2-staff-console-ui";
 import { phase6IntegrationMonitorChecklist } from "../flows/phase6-integration-monitor";
 import { phase5B2BOpsChecklist } from "../flows/phase5-b2b-ops";
 import { phase8ComplianceOpsChecklist } from "../flows/phase8-compliance-ops";
@@ -9,7 +9,13 @@ export function adminHomePageScaffold() {
     description: "Manage memberships, classes, waivers, contracts, and operations.",
     brandRule: "Proof counts. Rank is earned weekly.",
     phase2: {
-      modules: [...phase2StaffOpsChecklist],
+      modules: [...phase2StaffConsoleUiChecklist],
+      screenFlow: "staff access gate -> membership queue -> approve/reject -> role assignment -> refreshed snapshot",
+      recoverableErrors: [
+        "ADMIN_MEMBERSHIP_UPDATE_FAILED",
+        "ADMIN_ROLE_ASSIGN_FAILED",
+        "ADMIN_PENDING_MEMBERSHIPS_FAILED"
+      ],
       serviceSurface: [
         "GymAdminService.getGymOpsSummary",
         "GymAdminService.listGymMemberships",
@@ -17,6 +23,7 @@ export function adminHomePageScaffold() {
         "GymAdminService.listPendingWaitlistEntries",
         "GymAdminService.listUpcomingClasses",
         "GymAdminService.approveMembership",
+        "GymAdminService.updateMembershipStatus",
         "GymAdminService.assignMembershipRole",
         "GymAdminService.listUserConsentRecords",
         "GymAdminService.listOpenPrivacyRequests"

--- a/apps/admin/src/flows/phase2-staff-console-ui.ts
+++ b/apps/admin/src/flows/phase2-staff-console-ui.ts
@@ -1,0 +1,253 @@
+import type { GymMembership, GymRole, MembershipStatus } from "@kruxt/types";
+
+import {
+  createAdminSupabaseClient,
+  GymAdminService,
+  KruxtAdminError,
+  type GymClassScheduleItem,
+  type OpenPrivacyRequest,
+  type PendingWaitlistEntry,
+  type PrivacyOpsMetrics
+} from "../services";
+import { phase2StaffOpsChecklist } from "./phase2-staff-ops";
+
+export type StaffConsoleUiStep =
+  | "access"
+  | "queue"
+  | "membership_status"
+  | "role_assignment"
+  | "snapshot_refresh";
+
+export interface StaffMembershipItem extends GymMembership {
+  isPending: boolean;
+  canApprove: boolean;
+  canReject: boolean;
+  canAssignRole: boolean;
+}
+
+export interface Phase2StaffConsoleSnapshot {
+  gymId: string;
+  memberships: StaffMembershipItem[];
+  pendingMemberships: StaffMembershipItem[];
+  upcomingClasses: GymClassScheduleItem[];
+  pendingWaitlist: PendingWaitlistEntry[];
+  openPrivacyRequests: OpenPrivacyRequest[];
+  privacyMetrics: PrivacyOpsMetrics;
+}
+
+export interface StaffConsoleUiError {
+  code: string;
+  step: StaffConsoleUiStep;
+  message: string;
+  recoverable: boolean;
+}
+
+export interface StaffConsoleLoadSuccess {
+  ok: true;
+  snapshot: Phase2StaffConsoleSnapshot;
+}
+
+export interface StaffConsoleLoadFailure {
+  ok: false;
+  error: StaffConsoleUiError;
+}
+
+export type StaffConsoleLoadResult = StaffConsoleLoadSuccess | StaffConsoleLoadFailure;
+
+export interface StaffConsoleMutationSuccess {
+  ok: true;
+  action: "approve" | "reject" | "set_status" | "assign_role";
+  updatedMembership: GymMembership;
+  snapshot: Phase2StaffConsoleSnapshot;
+}
+
+export interface StaffConsoleMutationFailure {
+  ok: false;
+  error: StaffConsoleUiError;
+}
+
+export type StaffConsoleMutationResult = StaffConsoleMutationSuccess | StaffConsoleMutationFailure;
+
+const STATUS_ORDER: MembershipStatus[] = ["pending", "trial", "active", "paused", "cancelled"];
+const ROLE_ORDER: GymRole[] = ["leader", "officer", "coach", "member"];
+
+export const phase2StaffConsoleUiChecklist = [
+  ...phase2StaffOpsChecklist,
+  "Approve or reject pending memberships",
+  "Assign gym roles (leader/officer/coach/member)",
+  "Refresh console snapshot after every membership mutation"
+] as const;
+
+function statusRank(status: MembershipStatus): number {
+  const index = STATUS_ORDER.indexOf(status);
+  return index >= 0 ? index : STATUS_ORDER.length;
+}
+
+function roleRank(role: GymRole): number {
+  const index = ROLE_ORDER.indexOf(role);
+  return index >= 0 ? index : ROLE_ORDER.length;
+}
+
+function mapMembershipItem(membership: GymMembership): StaffMembershipItem {
+  const isPending = membership.membershipStatus === "pending";
+
+  return {
+    ...membership,
+    isPending,
+    canApprove: isPending,
+    canReject: isPending,
+    canAssignRole: membership.membershipStatus === "trial" || membership.membershipStatus === "active"
+  };
+}
+
+function sortMemberships(left: StaffMembershipItem, right: StaffMembershipItem): number {
+  const statusDelta = statusRank(left.membershipStatus) - statusRank(right.membershipStatus);
+  if (statusDelta !== 0) {
+    return statusDelta;
+  }
+
+  const roleDelta = roleRank(left.role) - roleRank(right.role);
+  if (roleDelta !== 0) {
+    return roleDelta;
+  }
+
+  return left.userId.localeCompare(right.userId);
+}
+
+function mapErrorStep(code: string): StaffConsoleUiStep {
+  if (["ADMIN_AUTH_REQUIRED", "ADMIN_STAFF_ACCESS_DENIED", "ADMIN_STAFF_ACCESS_CHECK_FAILED"].includes(code)) {
+    return "access";
+  }
+
+  if (["ADMIN_PENDING_MEMBERSHIPS_FAILED"].includes(code)) {
+    return "queue";
+  }
+
+  if (["ADMIN_MEMBERSHIP_UPDATE_FAILED"].includes(code)) {
+    return "membership_status";
+  }
+
+  if (["ADMIN_ROLE_ASSIGN_FAILED"].includes(code)) {
+    return "role_assignment";
+  }
+
+  return "snapshot_refresh";
+}
+
+function mapErrorMessage(code: string, fallback: string): string {
+  if (code === "ADMIN_STAFF_ACCESS_DENIED") {
+    return "Staff access is required to manage this gym.";
+  }
+
+  if (code === "ADMIN_AUTH_REQUIRED") {
+    return "Sign in is required before using staff actions.";
+  }
+
+  if (code === "ADMIN_MEMBERSHIP_UPDATE_FAILED") {
+    return "Membership update failed. Refresh and retry.";
+  }
+
+  if (code === "ADMIN_ROLE_ASSIGN_FAILED") {
+    return "Role assignment failed. Refresh and retry.";
+  }
+
+  return fallback;
+}
+
+function mapUiError(error: unknown): StaffConsoleUiError {
+  const appError =
+    error instanceof KruxtAdminError
+      ? error
+      : new KruxtAdminError("ADMIN_CONSOLE_ACTION_FAILED", "Unable to complete staff action.", error);
+
+  return {
+    code: appError.code,
+    step: mapErrorStep(appError.code),
+    message: mapErrorMessage(appError.code, appError.message),
+    recoverable: !["ADMIN_STAFF_ACCESS_DENIED", "ADMIN_AUTH_REQUIRED"].includes(appError.code)
+  };
+}
+
+export function createPhase2StaffConsoleUiFlow() {
+  const supabase = createAdminSupabaseClient();
+  const admin = new GymAdminService(supabase);
+
+  const loadSnapshot = async (gymId: string): Promise<Phase2StaffConsoleSnapshot> => {
+    const [memberships, upcomingClasses, pendingWaitlist, openPrivacyRequests, privacyMetrics] =
+      await Promise.all([
+        admin.listGymMemberships(gymId),
+        admin.listUpcomingClasses(gymId, 20),
+        admin.listPendingWaitlistEntries(gymId, 50),
+        admin.listOpenPrivacyRequests(gymId),
+        admin.getPrivacyOpsMetrics(gymId, 30)
+      ]);
+
+    const membershipItems = memberships.map(mapMembershipItem).sort(sortMemberships);
+
+    return {
+      gymId,
+      memberships: membershipItems,
+      pendingMemberships: membershipItems.filter((membership) => membership.membershipStatus === "pending"),
+      upcomingClasses,
+      pendingWaitlist,
+      openPrivacyRequests,
+      privacyMetrics
+    };
+  };
+
+  const runMutation = async (
+    gymId: string,
+    action: StaffConsoleMutationSuccess["action"],
+    mutate: () => Promise<GymMembership>
+  ): Promise<StaffConsoleMutationResult> => {
+    try {
+      const updatedMembership = await mutate();
+      const snapshot = await loadSnapshot(gymId);
+
+      return {
+        ok: true,
+        action,
+        updatedMembership,
+        snapshot
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: mapUiError(error)
+      };
+    }
+  };
+
+  return {
+    checklist: [...phase2StaffConsoleUiChecklist],
+    load: async (gymId: string): Promise<StaffConsoleLoadResult> => {
+      try {
+        return {
+          ok: true,
+          snapshot: await loadSnapshot(gymId)
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    },
+    approvePendingMembership: async (gymId: string, membershipId: string): Promise<StaffConsoleMutationResult> =>
+      runMutation(gymId, "approve", () => admin.approveMembership(gymId, membershipId)),
+    rejectPendingMembership: async (gymId: string, membershipId: string): Promise<StaffConsoleMutationResult> =>
+      runMutation(gymId, "reject", () => admin.updateMembershipStatus(gymId, membershipId, "cancelled")),
+    setMembershipStatus: async (
+      gymId: string,
+      membershipId: string,
+      status: MembershipStatus
+    ): Promise<StaffConsoleMutationResult> =>
+      runMutation(gymId, "set_status", () => admin.updateMembershipStatus(gymId, membershipId, status)),
+    assignMembershipRole: async (
+      gymId: string,
+      membershipId: string,
+      role: GymRole
+    ): Promise<StaffConsoleMutationResult> =>
+      runMutation(gymId, "assign_role", () => admin.assignMembershipRole(gymId, membershipId, role))
+  };
+}

--- a/apps/admin/src/index.ts
+++ b/apps/admin/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./app/page";
 export * from "./services";
 export * from "./flows/phase2-staff-ops";
+export * from "./flows/phase2-staff-console-ui";
 export * from "./flows/phase5-b2b-ops";
 export * from "./flows/phase6-integration-monitor";
 export * from "./flows/phase8-compliance-ops";

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -16,7 +16,7 @@
 ## Ordered build sequence
 
 1. Apply DB migration and seed data in Supabase project.
-2. Connect auth flow in mobile/admin to `profiles` creation, consent capture, guild hall load, and staff ops snapshot (`createPhase2OnboardingUiFlow` for mobile screens).
+2. Connect auth flow in mobile/admin to `profiles` creation, consent capture, guild hall load, and staff ops snapshot (`createPhase2OnboardingUiFlow` + `createPhase2StaffConsoleUiFlow`).
 3. Implement workout logger UI and call `log_workout_atomic` RPC (see `createPhase3WorkoutLoggingFlow`).
 4. Build feed UI from `createPhase4SocialFeedFlow` (`feed_events` + joined `workouts` + `social_interactions`).
 5. Connect admin UI screens to `createPhase5B2BOpsFlow` and `B2BOpsService`.

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -6,6 +6,7 @@
 - Phase 1: complete Supabase schema v2 migration with RLS, RPCs, triggers, seed flags
 - Phase 2 runtime: mobile onboarding + guild hall flows + admin staff ops/triage services
 - Phase 2 mobile UI wiring: onboarding screen controller with recoverable step-level errors and submit routing
+- Phase 2 admin UI wiring: staff console controller with queue actions and post-mutation snapshot refresh
 - Phase 3 runtime: workout logging flow with proof-feed and progress verification
 - Phase 4 runtime: social graph/feed ranking/notification service layer for mobile
 - Phase 5 runtime: admin B2B ops service layer for classes, waitlist, waivers, contracts, check-ins, and billing telemetry

--- a/docs/phase2-admin-console-ui-wiring.md
+++ b/docs/phase2-admin-console-ui-wiring.md
@@ -1,0 +1,43 @@
+# Phase 2 Admin Console UI Wiring
+
+Use `createPhase2StaffConsoleUiFlow` as the controller for gym staff membership operations.
+
+## Operator screen sequence
+
+1. Access gate (`require staff membership`)
+2. Membership queue (`pending` first)
+3. Approve/reject actions
+4. Role assignment actions
+5. Refreshed snapshot render
+
+## Runtime contract
+
+- `load(gymId)`
+  - returns `{ ok: true, snapshot }` or `{ ok: false, error }`
+- `approvePendingMembership(gymId, membershipId)`
+- `rejectPendingMembership(gymId, membershipId)`
+- `setMembershipStatus(gymId, membershipId, status)`
+- `assignMembershipRole(gymId, membershipId, role)`
+
+All mutation methods return a full refreshed snapshot so UI reflects latest state without extra calls.
+
+## Error handling
+
+Error shape:
+
+- `code`
+- `step` (`access`, `queue`, `membership_status`, `role_assignment`, `snapshot_refresh`)
+- `message`
+- `recoverable`
+
+Recommended UI behavior:
+
+- if `recoverable = true`, keep operator on current screen and show retry CTA
+- if `recoverable = false` (for example staff access denied), block action controls and route to unauthorized view
+
+## Acceptance mapping
+
+- Non-staff users cannot execute staff actions (`ADMIN_STAFF_ACCESS_DENIED`)
+- Staff can approve pending members (`approvePendingMembership`)
+- Staff can change member role (`assignMembershipRole`)
+- UI reflects latest state after every mutation (`snapshot` returned on success)

--- a/docs/phase2-runtime.md
+++ b/docs/phase2-runtime.md
@@ -30,6 +30,7 @@ Core methods:
 - `apps/admin/src/services/staff-access-service.ts`
 - `apps/admin/src/services/gym-admin-service.ts`
 - `apps/admin/src/flows/phase2-staff-ops.ts`
+- `apps/admin/src/flows/phase2-staff-console-ui.ts`
 
 Core methods:
 
@@ -43,6 +44,10 @@ Core methods:
 - `GymAdminService.assignMembershipRole(...)`
 - `GymAdminService.listUserConsentRecords(...)`
 - `GymAdminService.listOpenPrivacyRequests(...)`
+- `createPhase2StaffConsoleUiFlow(...).load(...)`
+- `createPhase2StaffConsoleUiFlow(...).approvePendingMembership(...)`
+- `createPhase2StaffConsoleUiFlow(...).rejectPendingMembership(...)`
+- `createPhase2StaffConsoleUiFlow(...).assignMembershipRole(...)`
 
 Supporting DB RPCs for strict-RLS admin reads:
 
@@ -59,5 +64,11 @@ Supporting DB RPCs for strict-RLS admin reads:
   - end-to-end submit that returns `nextRoute = guild_hall`
 - Mobile app can load guild hall state after onboarding/auth via `createGuildHallFlow`.
 - Admin routes should enforce `requireGymStaff` before any management action.
+- Admin membership queue screens should use `createPhase2StaffConsoleUiFlow` so:
+  - non-staff access attempts fail at action boundary
+  - approve/reject/role actions return refreshed membership snapshot
+  - UI always reflects latest membership state after each action
 - All actions rely on existing RLS policies in the migration file.
-- Detailed screen wiring reference: `docs/phase2-mobile-onboarding-ui-wiring.md`.
+- Detailed screen wiring references:
+  - `docs/phase2-mobile-onboarding-ui-wiring.md`
+  - `docs/phase2-admin-console-ui-wiring.md`

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -91,6 +91,13 @@
 69. Weekly `rank-recompute-weekly` scheduler run produces artifact report and exits non-zero on recompute failure.
 70. Failed scheduler run creates a high-priority phase-7 alert issue with workflow run URL.
 
+## Phase 2 Admin Console
+
+71. Non-staff actor receives `ADMIN_STAFF_ACCESS_DENIED` on load and all membership mutations.
+72. `approvePendingMembership` transitions pending member to active and returns refreshed snapshot with queue update.
+73. `rejectPendingMembership` transitions pending member to cancelled and removes it from pending queue on refreshed snapshot.
+74. `assignMembershipRole` updates role and refreshed snapshot reflects new role immediately.
+
 ## Performance targets for pilot
 
 - Feed p95 load < 500ms for 50-card page.


### PR DESCRIPTION
## Summary
- add `createPhase2StaffConsoleUiFlow` as the admin UI controller for staff membership operations
- wire load + mutation contracts (`approve`, `reject`, `set status`, `assign role`) to always return refreshed snapshot state
- add step-aware, user-readable admin error mapping for access/queue/status/role/snapshot states
- update admin scaffold metadata and Phase 2 docs/runbooks to use the new UI controller flow

## Validation
- `apps/admin/node_modules/.bin/tsc --noEmit -p apps/admin/tsconfig.json`
- `bash packages/db/tests/run_smoke.sh`

## Acceptance coverage
- non-staff users cannot execute staff actions (service boundary enforced, mapped UI error)
- staff can approve pending members and assign roles through dedicated flow actions
- UI gets latest membership state after each mutation via refreshed snapshot return

Closes #4
