### PR TITLE
feat(phase3-mobile): wire WorkoutLogger UI flow to log_workout_atomic

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ Operational features are controlled by flags in `public.feature_flags`.
 ## Phase 3 Runtime
 
 - Workout logging service + flow: `apps/mobile/src/services/workout-service.ts`, `apps/mobile/src/flows/phase3-workout-logging.ts`
+- WorkoutLogger UI controller: `apps/mobile/src/flows/phase3-workout-logger-ui.ts`
 - PR auto-detection trigger migration: `packages/db/supabase/migrations/202602190351_krux_beta_part3_s010.sql`
 - Usage notes: `docs/phase3-runtime.md`
+- Screen wiring guide: `docs/phase3-workout-logger-ui-wiring.md`
 
 ## Phase 4 Runtime
 

--- a/apps/mobile/src/app.tsx
+++ b/apps/mobile/src/app.tsx
@@ -46,7 +46,14 @@ export function mobileAppScaffold() {
     },
     phase3: {
       flow: "consent gate check -> log workout -> auto proof post -> xp/chain/rank progress",
+      screenFlow: "metadata -> exercise blocks -> sets -> visibility -> review -> submit",
       checklist: [...phase3WorkoutLoggingChecklist],
+      recoverableErrors: [
+        "WORKOUT_LOGGER_VALIDATION_FAILED",
+        "RECONSENT_REQUIRED",
+        "WORKOUT_LOG_RPC_FAILED",
+        "WORKOUT_LOGGER_SIGNALS_INCOMPLETE"
+      ],
       rpcEndpoints: ["log_workout_atomic"],
       expectedSignals: ["feed_events.workout_logged", "feed_events.pr_verified", "profiles.xp_total"]
     },

--- a/apps/mobile/src/flows/phase3-workout-logger-ui.ts
+++ b/apps/mobile/src/flows/phase3-workout-logger-ui.ts
@@ -1,0 +1,376 @@
+import type {
+  LogWorkoutAtomicInput,
+  LogWorkoutExerciseInput,
+  LogWorkoutSetInput,
+  WorkoutType,
+  WorkoutVisibility
+} from "@kruxt/types";
+import { translateLegalText } from "@kruxt/types";
+
+import {
+  createMobileSupabaseClient,
+  KruxtAppError,
+  type LogWorkoutAtomicResult,
+  WorkoutService
+} from "../services";
+import { phase3WorkoutLoggingChecklistKeys } from "./phase3-workout-logging";
+
+export type WorkoutLoggerUiStep = "metadata" | "exercise_blocks" | "sets" | "review";
+
+export interface WorkoutLoggerSetDraft {
+  clientId: string;
+  reps?: number;
+  weightKg?: number;
+  durationSeconds?: number;
+  distanceM?: number;
+  rpe?: number;
+}
+
+export interface WorkoutLoggerExerciseDraft {
+  clientId: string;
+  exerciseId: string;
+  notes?: string;
+  targetReps?: string;
+  targetWeightKg?: number;
+  sets: WorkoutLoggerSetDraft[];
+}
+
+export interface WorkoutLoggerMetadataDraft {
+  gymId?: string;
+  title: string;
+  workoutType: WorkoutType;
+  notes?: string;
+  startedAt?: string;
+  endedAt?: string;
+  rpe?: number;
+  visibility: WorkoutVisibility;
+}
+
+export interface WorkoutLoggerDraft {
+  metadata: WorkoutLoggerMetadataDraft;
+  exercises: WorkoutLoggerExerciseDraft[];
+}
+
+export interface WorkoutLoggerFieldError {
+  field: string;
+  message: string;
+}
+
+export interface WorkoutLoggerSubmitVerification {
+  totalsUpdated: boolean;
+  proofEventCreated: boolean;
+  progressUpdated: boolean;
+}
+
+export interface WorkoutLoggerUiError {
+  code: string;
+  step: WorkoutLoggerUiStep;
+  message: string;
+  recoverable: boolean;
+  fieldErrors: WorkoutLoggerFieldError[];
+}
+
+export interface WorkoutLoggerSubmitSuccess {
+  ok: true;
+  result: LogWorkoutAtomicResult;
+  verification: WorkoutLoggerSubmitVerification;
+}
+
+export interface WorkoutLoggerSubmitFailure {
+  ok: false;
+  error: WorkoutLoggerUiError;
+}
+
+export type WorkoutLoggerSubmitResult = WorkoutLoggerSubmitSuccess | WorkoutLoggerSubmitFailure;
+
+export const phase3WorkoutLoggerUiChecklist = [
+  ...phase3WorkoutLoggingChecklistKeys.map((key) => translateLegalText(key)),
+  "Keep log interactions under 60 seconds",
+  "Return proof + progress signals after submit"
+] as const;
+
+function createClientId(prefix: string): string {
+  const randomPart = Math.random().toString(36).slice(2, 10);
+  return `${prefix}_${Date.now()}_${randomPart}`;
+}
+
+function createEmptySet(): WorkoutLoggerSetDraft {
+  return {
+    clientId: createClientId("set"),
+    reps: 8,
+    weightKg: 0,
+    rpe: 7
+  };
+}
+
+function createEmptyExercise(): WorkoutLoggerExerciseDraft {
+  return {
+    clientId: createClientId("exercise"),
+    exerciseId: "",
+    sets: [createEmptySet()]
+  };
+}
+
+function toAtomicInput(draft: WorkoutLoggerDraft): LogWorkoutAtomicInput {
+  const exercises: LogWorkoutExerciseInput[] = draft.exercises.map((exercise, exerciseIndex) => ({
+    exerciseId: exercise.exerciseId,
+    orderIndex: exerciseIndex + 1,
+    notes: exercise.notes,
+    targetReps: exercise.targetReps,
+    targetWeightKg: exercise.targetWeightKg,
+    sets: exercise.sets.map((set, setIndex) => {
+      const mappedSet: LogWorkoutSetInput = {
+        setIndex: setIndex + 1,
+        reps: set.reps,
+        weightKg: set.weightKg,
+        durationSeconds: set.durationSeconds,
+        distanceM: set.distanceM,
+        rpe: set.rpe
+      };
+
+      return mappedSet;
+    })
+  }));
+
+  return {
+    workout: {
+      gymId: draft.metadata.gymId,
+      title: draft.metadata.title,
+      workoutType: draft.metadata.workoutType,
+      notes: draft.metadata.notes,
+      startedAt: draft.metadata.startedAt,
+      endedAt: draft.metadata.endedAt,
+      rpe: draft.metadata.rpe,
+      visibility: draft.metadata.visibility,
+      source: "manual"
+    },
+    exercises
+  };
+}
+
+function mapFieldToStep(field: string): WorkoutLoggerUiStep {
+  if (field.startsWith("metadata.")) {
+    return "metadata";
+  }
+
+  if (field.startsWith("exercises.")) {
+    return field.includes(".sets.") ? "sets" : "exercise_blocks";
+  }
+
+  return "review";
+}
+
+function validateDraft(draft: WorkoutLoggerDraft): WorkoutLoggerFieldError[] {
+  const errors: WorkoutLoggerFieldError[] = [];
+
+  if (!draft.metadata.title.trim()) {
+    errors.push({
+      field: "metadata.title",
+      message: "Workout title is required."
+    });
+  }
+
+  if (draft.metadata.rpe !== undefined && (draft.metadata.rpe < 1 || draft.metadata.rpe > 10)) {
+    errors.push({
+      field: "metadata.rpe",
+      message: "Workout RPE must be between 1 and 10."
+    });
+  }
+
+  if (draft.exercises.length === 0) {
+    errors.push({
+      field: "exercises",
+      message: "Add at least one exercise block."
+    });
+  }
+
+  draft.exercises.forEach((exercise, exerciseIndex) => {
+    if (!exercise.exerciseId.trim()) {
+      errors.push({
+        field: `exercises.${exerciseIndex}.exerciseId`,
+        message: "Select an exercise."
+      });
+    }
+
+    if (exercise.sets.length === 0) {
+      errors.push({
+        field: `exercises.${exerciseIndex}.sets`,
+        message: "Add at least one set."
+      });
+    }
+
+    exercise.sets.forEach((set, setIndex) => {
+      const hasVolumeSignal =
+        (set.reps ?? 0) > 0 ||
+        (set.durationSeconds ?? 0) > 0 ||
+        (set.distanceM ?? 0) > 0;
+
+      if (!hasVolumeSignal) {
+        errors.push({
+          field: `exercises.${exerciseIndex}.sets.${setIndex}`,
+          message: "Each set must include reps, duration, or distance."
+        });
+      }
+
+      if (set.reps !== undefined && set.reps < 0) {
+        errors.push({
+          field: `exercises.${exerciseIndex}.sets.${setIndex}.reps`,
+          message: "Reps cannot be negative."
+        });
+      }
+
+      if (set.weightKg !== undefined && set.weightKg < 0) {
+        errors.push({
+          field: `exercises.${exerciseIndex}.sets.${setIndex}.weightKg`,
+          message: "Weight cannot be negative."
+        });
+      }
+
+      if (set.rpe !== undefined && (set.rpe < 1 || set.rpe > 10)) {
+        errors.push({
+          field: `exercises.${exerciseIndex}.sets.${setIndex}.rpe`,
+          message: "Set RPE must be between 1 and 10."
+        });
+      }
+    });
+  });
+
+  return errors;
+}
+
+function mapRuntimeError(error: unknown, locale?: string | null): WorkoutLoggerUiError {
+  const appError =
+    error instanceof KruxtAppError
+      ? error
+      : new KruxtAppError("WORKOUT_LOGGER_SUBMIT_FAILED", "Unable to submit workout log.", error);
+
+  let step: WorkoutLoggerUiStep = "review";
+  if (["WORKOUT_EXERCISES_REQUIRED"].includes(appError.code)) {
+    step = "exercise_blocks";
+  } else if (["CONSENT_GAPS_READ_FAILED", "CONSENT_GATE_CHECK_FAILED", "RECONSENT_REQUIRED"].includes(appError.code)) {
+    step = "review";
+  }
+
+  let message = appError.message;
+  if (appError.code === "RECONSENT_REQUIRED") {
+    message = translateLegalText("legal.error.reconsent_required_workout", { locale });
+  }
+
+  return {
+    code: appError.code,
+    step,
+    message,
+    recoverable: appError.code !== "AUTH_REQUIRED",
+    fieldErrors: []
+  };
+}
+
+export function createPhase3WorkoutLoggerUiFlow(options: { locale?: string | null } = {}) {
+  const supabase = createMobileSupabaseClient();
+  const workouts = new WorkoutService(supabase, { locale: options.locale });
+  const checklist = phase3WorkoutLoggingChecklistKeys.map((key) =>
+    translateLegalText(key, { locale: options.locale })
+  );
+
+  return {
+    checklist,
+    checklistKeys: phase3WorkoutLoggingChecklistKeys,
+    createDraft: (overrides: Partial<WorkoutLoggerDraft> = {}): WorkoutLoggerDraft => ({
+      metadata: {
+        title: "Workout Session",
+        workoutType: "strength",
+        visibility: "public",
+        ...overrides.metadata
+      },
+      exercises: overrides.exercises ? [...overrides.exercises] : [createEmptyExercise()]
+    }),
+    addExercise: (draft: WorkoutLoggerDraft): WorkoutLoggerDraft => ({
+      ...draft,
+      exercises: [...draft.exercises, createEmptyExercise()]
+    }),
+    removeExercise: (draft: WorkoutLoggerDraft, exerciseIndex: number): WorkoutLoggerDraft => ({
+      ...draft,
+      exercises: draft.exercises.filter((_, index) => index !== exerciseIndex)
+    }),
+    addSet: (draft: WorkoutLoggerDraft, exerciseIndex: number): WorkoutLoggerDraft => ({
+      ...draft,
+      exercises: draft.exercises.map((exercise, index) => {
+        if (index !== exerciseIndex) {
+          return exercise;
+        }
+
+        return {
+          ...exercise,
+          sets: [...exercise.sets, createEmptySet()]
+        };
+      })
+    }),
+    removeSet: (
+      draft: WorkoutLoggerDraft,
+      exerciseIndex: number,
+      setIndex: number
+    ): WorkoutLoggerDraft => ({
+      ...draft,
+      exercises: draft.exercises.map((exercise, index) => {
+        if (index !== exerciseIndex) {
+          return exercise;
+        }
+
+        return {
+          ...exercise,
+          sets: exercise.sets.filter((_, index2) => index2 !== setIndex)
+        };
+      })
+    }),
+    validate: (draft: WorkoutLoggerDraft): WorkoutLoggerFieldError[] => validateDraft(draft),
+    submit: async (draft: WorkoutLoggerDraft): Promise<WorkoutLoggerSubmitResult> => {
+      const fieldErrors = validateDraft(draft);
+      if (fieldErrors.length > 0) {
+        return {
+          ok: false,
+          error: {
+            code: "WORKOUT_LOGGER_VALIDATION_FAILED",
+            step: mapFieldToStep(fieldErrors[0]?.field ?? "review"),
+            message: "Review highlighted workout fields and retry.",
+            recoverable: true,
+            fieldErrors
+          }
+        };
+      }
+
+      try {
+        const result = await workouts.logWorkoutAtomic(toAtomicInput(draft));
+        const verification: WorkoutLoggerSubmitVerification = {
+          totalsUpdated: result.workout.totalSets > 0,
+          proofEventCreated: result.proofEvents.some((event) => event.eventType === "workout_logged"),
+          progressUpdated: Boolean(result.progress.lastWorkoutAt) && result.progress.chainDays > 0
+        };
+
+        if (!verification.totalsUpdated || !verification.proofEventCreated || !verification.progressUpdated) {
+          return {
+            ok: false,
+            error: {
+              code: "WORKOUT_LOGGER_SIGNALS_INCOMPLETE",
+              step: "review",
+              message:
+                "Workout saved but one or more progression signals are missing. Refresh and verify before continuing.",
+              recoverable: true,
+              fieldErrors: []
+            }
+          };
+        }
+
+        return {
+          ok: true,
+          result,
+          verification
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapRuntimeError(error, options.locale)
+        };
+      }
+    }
+  };
+}

--- a/apps/mobile/src/index.ts
+++ b/apps/mobile/src/index.ts
@@ -4,6 +4,7 @@ export * from "./flows/phase2-onboarding";
 export * from "./flows/phase2-onboarding-ui";
 export * from "./flows/guild-hall";
 export * from "./flows/phase3-workout-logging";
+export * from "./flows/phase3-workout-logger-ui";
 export * from "./flows/phase4-social-feed";
 export * from "./flows/phase6-integrations";
 export * from "./flows/phase7-rank-trials";

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -17,7 +17,7 @@
 
 1. Apply DB migration and seed data in Supabase project.
 2. Connect auth flow in mobile/admin to `profiles` creation, consent capture, guild hall load, and staff ops snapshot (`createPhase2OnboardingUiFlow` + `createPhase2StaffConsoleUiFlow`).
-3. Implement workout logger UI and call `log_workout_atomic` RPC (see `createPhase3WorkoutLoggingFlow`).
+3. Implement workout logger UI and call `log_workout_atomic` RPC (see `createPhase3WorkoutLoggerUiFlow`).
 4. Build feed UI from `createPhase4SocialFeedFlow` (`feed_events` + joined `workouts` + `social_interactions`).
 5. Connect admin UI screens to `createPhase5B2BOpsFlow` and `B2BOpsService`.
 6. Connect integration monitoring UI to `createPhase6IntegrationMonitorFlow`.

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -8,6 +8,7 @@
 - Phase 2 mobile UI wiring: onboarding screen controller with recoverable step-level errors and submit routing
 - Phase 2 admin UI wiring: staff console controller with queue actions and post-mutation snapshot refresh
 - Phase 3 runtime: workout logging flow with proof-feed and progress verification
+- Phase 3 mobile UI wiring: WorkoutLogger controller with draft helpers, validation, and signal checks
 - Phase 4 runtime: social graph/feed ranking/notification service layer for mobile
 - Phase 5 runtime: admin B2B ops service layer for classes, waitlist, waivers, contracts, check-ins, and billing telemetry
 - Phase 6 runtime: Apple/Garmin integration pipeline (mobile integration service + webhook ingest + sync dispatcher + cursor persistence)

--- a/docs/phase3-runtime.md
+++ b/docs/phase3-runtime.md
@@ -12,11 +12,14 @@ Phase 3 runtime now includes a concrete workout logging path that validates:
 
 - `apps/mobile/src/services/workout-service.ts`
 - `apps/mobile/src/flows/phase3-workout-logging.ts`
+- `apps/mobile/src/flows/phase3-workout-logger-ui.ts`
 
 Core methods:
 
 - `WorkoutService.logWorkoutAtomic(...)`
 - `createPhase3WorkoutLoggingFlow().run(...)`
+- `createPhase3WorkoutLoggerUiFlow().validate(...)`
+- `createPhase3WorkoutLoggerUiFlow().submit(...)`
 
 ## DB migration hooks
 
@@ -24,3 +27,11 @@ Core methods:
 - `packages/db/supabase/migrations/202602190353_krux_beta_part3_s012.sql`
 
 These add the PR detection trigger pipeline for `public.workout_sets`.
+
+## Wiring expectations
+
+- Workout logger screens should use `createPhase3WorkoutLoggerUiFlow` for:
+  - sub-60-second set/exercise interactions (`addExercise`, `addSet`, `removeSet`)
+  - field-level validation before submit
+  - post-submit verification of totals/feed/progress signals
+- Runtime wiring details: `docs/phase3-workout-logger-ui-wiring.md`.

--- a/docs/phase3-workout-logger-ui-wiring.md
+++ b/docs/phase3-workout-logger-ui-wiring.md
@@ -1,0 +1,47 @@
+# Phase 3 WorkoutLogger UI Wiring
+
+Use `createPhase3WorkoutLoggerUiFlow` as the controller for WorkoutLogger screens.
+
+## Screen sequence
+
+1. `metadata` (title, type, notes, visibility)
+2. `exercise_blocks` (exercise selection + ordering)
+3. `sets` (reps/weight/RPE, optional duration/distance)
+4. `review`
+5. submit and confirm proof/progress signals
+
+## Runtime contract
+
+- `createDraft(overrides?)`
+- `addExercise(draft)` / `removeExercise(draft, index)`
+- `addSet(draft, exerciseIndex)` / `removeSet(draft, exerciseIndex, setIndex)`
+- `validate(draft)` returns field-level errors
+- `submit(draft)` returns:
+  - success: `{ ok: true, result, verification }`
+  - failure: `{ ok: false, error }`
+
+## Verification guarantees on submit
+
+`submit` verifies these acceptance signals before returning success:
+
+- `totalsUpdated`: `workout.totalSets > 0`
+- `proofEventCreated`: at least one `workout_logged` feed event exists
+- `progressUpdated`: `lastWorkoutAt` is present and `chainDays > 0`
+
+If one signal is missing, submit returns a recoverable failure with code `WORKOUT_LOGGER_SIGNALS_INCOMPLETE`.
+
+## Error handling model
+
+Error shape:
+
+- `code`
+- `step` (`metadata`, `exercise_blocks`, `sets`, `review`)
+- `message`
+- `recoverable`
+- `fieldErrors`
+
+Recommended UX behavior:
+
+- For validation failures, focus first invalid field and keep user on the mapped step.
+- For `RECONSENT_REQUIRED`, route to consent update flow before retrying submit.
+- For recoverable review-step errors, keep draft state and allow one-tap retry.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -98,6 +98,13 @@
 73. `rejectPendingMembership` transitions pending member to cancelled and removes it from pending queue on refreshed snapshot.
 74. `assignMembershipRole` updates role and refreshed snapshot reflects new role immediately.
 
+## Phase 3 WorkoutLogger UI
+
+75. `createPhase3WorkoutLoggerUiFlow.validate` returns field-level errors for missing exercise IDs and empty set payloads.
+76. `submit` returns `WORKOUT_LOGGER_VALIDATION_FAILED` without RPC call when draft validation fails.
+77. Successful submit returns verification flags with `totalsUpdated=true`, `proofEventCreated=true`, `progressUpdated=true`.
+78. Missing post-submit signals return recoverable `WORKOUT_LOGGER_SIGNALS_INCOMPLETE` error.
+
 ## Performance targets for pilot
 
 - Feed p95 load < 500ms for 50-card page.


### PR DESCRIPTION
## Summary
- add `createPhase3WorkoutLoggerUiFlow` for production WorkoutLogger screen wiring
- provide draft-state helpers for fast logging (`createDraft`, `addExercise`, `addSet`, `removeSet`)
- add step-level validation and structured recoverable UI errors
- enforce post-submit acceptance signal checks (totals, proof-feed event, progress updates)
- update mobile scaffold metadata and Phase 3 docs/runbook references

## Validation
- `apps/mobile/node_modules/.bin/tsc --noEmit -p apps/mobile/tsconfig.json`
- `bash packages/db/tests/run_smoke.sh`

## Acceptance coverage
- user can log workouts with sets/reps/weight/RPE via UI draft + submit contract
- submit verifies totals are updated (`totalSets > 0`)
- submit verifies proof feed event exists (`workout_logged`)
- submit verifies progression signal is present (`lastWorkoutAt` + `chainDays > 0`)

Closes #5
