### PR TITLE
feat(phase4-mobile): wire Proof Feed UI interactions and moderation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Operational features are controlled by flags in `public.feature_flags`.
 
 - Social/feed/notification services: `apps/mobile/src/services/social-service.ts`, `apps/mobile/src/services/feed-service.ts`, `apps/mobile/src/services/notification-service.ts`
 - Social feed flow: `apps/mobile/src/flows/phase4-social-feed.ts`
+- Proof Feed UI controller: `apps/mobile/src/flows/phase4-proof-feed-ui.ts`
 - Push token schema + RLS migration set starts at: `packages/db/supabase/migrations/202602190355_krux_beta_part3_s014.sql`
 - Usage notes: `docs/phase4-runtime.md`
+- Screen wiring guide: `docs/phase4-proof-feed-ui-wiring.md`
 
 ## Phase 5 Runtime
 

--- a/apps/mobile/src/app.tsx
+++ b/apps/mobile/src/app.tsx
@@ -59,7 +59,14 @@ export function mobileAppScaffold() {
     },
     phase4: {
       flow: "load ranked feed -> social interactions -> moderation safety -> notifications",
+      screenFlow: "proof feed cards -> react/comment -> block/report -> refreshed feed snapshot",
       checklist: [...phase4SocialFeedChecklist],
+      recoverableErrors: [
+        "SOCIAL_REACTION_CREATE_FAILED",
+        "SOCIAL_COMMENT_CREATE_FAILED",
+        "SOCIAL_REPORT_CREATE_FAILED",
+        "SOCIAL_BLOCK_CREATE_FAILED"
+      ],
       tables: [
         "feed_events",
         "social_connections",

--- a/apps/mobile/src/flows/phase4-proof-feed-ui.ts
+++ b/apps/mobile/src/flows/phase4-proof-feed-ui.ts
@@ -1,0 +1,275 @@
+import type {
+  ReactionType,
+  SocialInteraction,
+  SocialConnection,
+  UserReportInput
+} from "@kruxt/types";
+
+import {
+  createMobileSupabaseClient,
+  FeedService,
+  KruxtAppError,
+  SocialService,
+  type RankedFeedItem,
+  type UserBlockRecord,
+  type UserReportRecord
+} from "../services";
+import { phase4SocialFeedChecklist } from "./phase4-social-feed";
+
+export type ProofFeedUiStep = "feed" | "reaction" | "comment" | "moderation";
+
+export interface ProofFeedSnapshot {
+  feed: RankedFeedItem[];
+  hiddenBlockedActorCount: number;
+  blockedUsers: UserBlockRecord[];
+  incomingFollowRequests: SocialConnection[];
+  myReports: UserReportRecord[];
+}
+
+export interface ProofFeedUiError {
+  code: string;
+  step: ProofFeedUiStep;
+  message: string;
+  recoverable: boolean;
+}
+
+export interface ProofFeedLoadSuccess {
+  ok: true;
+  snapshot: ProofFeedSnapshot;
+}
+
+export interface ProofFeedLoadFailure {
+  ok: false;
+  error: ProofFeedUiError;
+}
+
+export type ProofFeedLoadResult = ProofFeedLoadSuccess | ProofFeedLoadFailure;
+
+export interface ProofFeedMutationSuccess {
+  ok: true;
+  snapshot: ProofFeedSnapshot;
+  reaction?: SocialInteraction;
+  comment?: SocialInteraction;
+  thread?: SocialInteraction[];
+  block?: UserBlockRecord;
+  report?: UserReportRecord;
+}
+
+export interface ProofFeedMutationFailure {
+  ok: false;
+  error: ProofFeedUiError;
+}
+
+export type ProofFeedMutationResult = ProofFeedMutationSuccess | ProofFeedMutationFailure;
+
+export const phase4ProofFeedUiChecklist = [
+  ...phase4SocialFeedChecklist,
+  "Persist reactions and comments with immediate state refresh",
+  "Hide blocked actors from feed cards and interaction threads",
+  "Create moderation records from report actions"
+] as const;
+
+function mapErrorStep(code: string): ProofFeedUiStep {
+  if (code.startsWith("FEED_") || code === "AUTH_REQUIRED" || code === "AUTH_GET_USER_FAILED") {
+    return "feed";
+  }
+
+  if (code.includes("REACTION")) {
+    return "reaction";
+  }
+
+  if (code.includes("COMMENT") || code === "SOCIAL_INTERACTIONS_READ_FAILED") {
+    return "comment";
+  }
+
+  return "moderation";
+}
+
+function mapErrorMessage(code: string, fallback: string): string {
+  if (code === "SOCIAL_COMMENT_EMPTY") {
+    return "Comment cannot be empty.";
+  }
+
+  if (code === "SOCIAL_BLOCKED_BY_TARGET") {
+    return "This athlete has blocked you.";
+  }
+
+  if (code === "SOCIAL_BLOCK_SELF_FORBIDDEN") {
+    return "You cannot block your own profile.";
+  }
+
+  if (code === "SOCIAL_REPORT_REASON_REQUIRED") {
+    return "Add a reason before sending the report.";
+  }
+
+  return fallback;
+}
+
+function mapUiError(error: unknown): ProofFeedUiError {
+  const appError =
+    error instanceof KruxtAppError
+      ? error
+      : new KruxtAppError("PROOF_FEED_UI_ACTION_FAILED", "Unable to complete feed action.", error);
+
+  return {
+    code: appError.code,
+    step: mapErrorStep(appError.code),
+    message: mapErrorMessage(appError.code, appError.message),
+    recoverable: appError.code !== "AUTH_REQUIRED"
+  };
+}
+
+function filterBlockedActors<T extends { actorUserId: string }>(
+  rows: T[],
+  blockedActorIds: Set<string>
+): T[] {
+  return rows.filter((row) => !blockedActorIds.has(row.actorUserId));
+}
+
+export function createPhase4ProofFeedUiFlow() {
+  const supabase = createMobileSupabaseClient();
+  const feed = new FeedService(supabase);
+  const social = new SocialService(supabase);
+
+  const loadSnapshot = async (userId?: string): Promise<ProofFeedSnapshot> => {
+    const [rankedFeed, blockedUsers, incomingFollowRequests, myReports] = await Promise.all([
+      feed.listHomeFeed({ limit: 30, scanLimit: 150 }, userId),
+      social.listMyBlocks(userId),
+      social.listIncomingFollowRequests(userId, 50),
+      social.listMyReports(userId, 30)
+    ]);
+
+    const blockedActorIds = new Set(blockedUsers.map((row) => row.blockedUserId));
+    const visibleFeed = rankedFeed.filter((item) => !blockedActorIds.has(item.actor.userId));
+
+    return {
+      feed: visibleFeed,
+      hiddenBlockedActorCount: rankedFeed.length - visibleFeed.length,
+      blockedUsers,
+      incomingFollowRequests,
+      myReports
+    };
+  };
+
+  const runMutation = async (
+    mutate: () => Promise<Partial<ProofFeedMutationSuccess>>,
+    userId?: string
+  ): Promise<ProofFeedMutationResult> => {
+    try {
+      const mutationPayload = await mutate();
+      const snapshot = await loadSnapshot(userId);
+
+      return {
+        ok: true,
+        snapshot,
+        ...mutationPayload
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: mapUiError(error)
+      };
+    }
+  };
+
+  return {
+    checklist: [...phase4ProofFeedUiChecklist],
+    load: async (userId?: string): Promise<ProofFeedLoadResult> => {
+      try {
+        return {
+          ok: true,
+          snapshot: await loadSnapshot(userId)
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    },
+    loadWorkoutThread: async (workoutId: string, userId?: string): Promise<SocialInteraction[]> => {
+      const [interactions, blockedUsers] = await Promise.all([
+        social.listWorkoutInteractions(workoutId, 200),
+        social.listMyBlocks(userId)
+      ]);
+      const blockedActorIds = new Set(blockedUsers.map((row) => row.blockedUserId));
+
+      return filterBlockedActors(
+        interactions.map((interaction) => ({
+          ...interaction,
+          actorUserId: interaction.actorUserId
+        })),
+        blockedActorIds
+      );
+    },
+    reactToWorkout: async (
+      workoutId: string,
+      reactionType: ReactionType | null,
+      userId?: string
+    ): Promise<ProofFeedMutationResult> =>
+      runMutation(async () => {
+        if (!reactionType) {
+          await social.removeReaction(workoutId, userId);
+          return {};
+        }
+
+        const reaction = await social.addReaction({ workoutId, reactionType }, userId);
+        return { reaction };
+      }, userId),
+    commentOnWorkout: async (
+      workoutId: string,
+      commentText: string,
+      options: { parentInteractionId?: string; userId?: string } = {}
+    ): Promise<ProofFeedMutationResult> =>
+      runMutation(async () => {
+        const comment = await social.addComment(
+          {
+            workoutId,
+            commentText,
+            parentInteractionId: options.parentInteractionId
+          },
+          options.userId
+        );
+
+        const [thread, blockedUsers] = await Promise.all([
+          social.listWorkoutInteractions(workoutId, 200),
+          social.listMyBlocks(options.userId)
+        ]);
+        const blockedActorIds = new Set(blockedUsers.map((row) => row.blockedUserId));
+        const filteredThread = filterBlockedActors(
+          thread.map((interaction) => ({
+            ...interaction,
+            actorUserId: interaction.actorUserId
+          })),
+          blockedActorIds
+        );
+
+        return {
+          comment,
+          thread: filteredThread
+        };
+      }, options.userId),
+    blockActor: async (
+      blockedUserId: string,
+      reason?: string,
+      userId?: string
+    ): Promise<ProofFeedMutationResult> =>
+      runMutation(async () => {
+        const block = await social.blockUser({ blockedUserId, reason }, userId);
+        return { block };
+      }, userId),
+    unblockActor: async (blockedUserId: string, userId?: string): Promise<ProofFeedMutationResult> =>
+      runMutation(async () => {
+        await social.unblockUser(blockedUserId, userId);
+        return {};
+      }, userId),
+    reportContent: async (
+      input: UserReportInput,
+      userId?: string
+    ): Promise<ProofFeedMutationResult> =>
+      runMutation(async () => {
+        const report = await social.createReport(input, userId);
+        return { report };
+      }, userId)
+  };
+}

--- a/apps/mobile/src/index.ts
+++ b/apps/mobile/src/index.ts
@@ -6,6 +6,7 @@ export * from "./flows/guild-hall";
 export * from "./flows/phase3-workout-logging";
 export * from "./flows/phase3-workout-logger-ui";
 export * from "./flows/phase4-social-feed";
+export * from "./flows/phase4-proof-feed-ui";
 export * from "./flows/phase6-integrations";
 export * from "./flows/phase7-rank-trials";
 export * from "./flows/phase8-privacy-requests";

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -18,7 +18,7 @@
 1. Apply DB migration and seed data in Supabase project.
 2. Connect auth flow in mobile/admin to `profiles` creation, consent capture, guild hall load, and staff ops snapshot (`createPhase2OnboardingUiFlow` + `createPhase2StaffConsoleUiFlow`).
 3. Implement workout logger UI and call `log_workout_atomic` RPC (see `createPhase3WorkoutLoggerUiFlow`).
-4. Build feed UI from `createPhase4SocialFeedFlow` (`feed_events` + joined `workouts` + `social_interactions`).
+4. Build feed UI from `createPhase4ProofFeedUiFlow` (`feed_events` + joined `workouts` + `social_interactions`).
 5. Connect admin UI screens to `createPhase5B2BOpsFlow` and `B2BOpsService`.
 6. Connect integration monitoring UI to `createPhase6IntegrationMonitorFlow`.
 7. Wire production provider credentials and scheduler cadence for `provider_webhook_ingest` + `sync_dispatcher`.

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -10,6 +10,7 @@
 - Phase 3 runtime: workout logging flow with proof-feed and progress verification
 - Phase 3 mobile UI wiring: WorkoutLogger controller with draft helpers, validation, and signal checks
 - Phase 4 runtime: social graph/feed ranking/notification service layer for mobile
+- Phase 4 mobile UI wiring: Proof Feed controller with interaction + moderation refresh loops
 - Phase 5 runtime: admin B2B ops service layer for classes, waitlist, waivers, contracts, check-ins, and billing telemetry
 - Phase 6 runtime: Apple/Garmin integration pipeline (mobile integration service + webhook ingest + sync dispatcher + cursor persistence)
 - Phase 6 monitoring runtime: admin integration health + sync failure monitor flow for gym staff

--- a/docs/phase4-proof-feed-ui-wiring.md
+++ b/docs/phase4-proof-feed-ui-wiring.md
@@ -1,0 +1,35 @@
+# Phase 4 Proof Feed UI Wiring
+
+Use `createPhase4ProofFeedUiFlow` as the single controller for Proof Feed interactions.
+
+## Screen sequence
+
+1. Load feed cards
+2. Render reaction/comment controls
+3. Apply moderation actions (block/report)
+4. Refresh and reconcile feed state
+
+## Runtime contract
+
+- `load(userId?)` -> `{ ok: true, snapshot }` or `{ ok: false, error }`
+- `loadWorkoutThread(workoutId, userId?)`
+- `reactToWorkout(workoutId, reactionType|null, userId?)`
+- `commentOnWorkout(workoutId, commentText, { parentInteractionId?, userId? })`
+- `blockActor(blockedUserId, reason?, userId?)`
+- `unblockActor(blockedUserId, userId?)`
+- `reportContent(input, userId?)`
+
+All mutation methods return a refreshed feed snapshot.
+
+## Feed safety behavior
+
+- Feed snapshot is filtered to remove blocked actor IDs.
+- Interaction threads are filtered to remove blocked actor interactions.
+- `hiddenBlockedActorCount` is included for telemetry/debug visibility.
+
+## Acceptance mapping
+
+- Feed renders only visible workouts after RLS + local blocked-actor filtering.
+- Reactions/comments persist and UI refreshes from server-backed state.
+- Blocking an actor removes their content from refreshed feed snapshot.
+- Reporting content creates moderation records via `user_reports`.

--- a/docs/phase4-runtime.md
+++ b/docs/phase4-runtime.md
@@ -13,6 +13,7 @@ Phase 4 runtime now includes mobile service-layer logic for:
 - `apps/mobile/src/services/feed-service.ts`
 - `apps/mobile/src/services/notification-service.ts`
 - `apps/mobile/src/flows/phase4-social-feed.ts`
+- `apps/mobile/src/flows/phase4-proof-feed-ui.ts`
 
 Core methods:
 
@@ -25,6 +26,10 @@ Core methods:
 - `FeedService.listHomeFeed(...)`
 - `NotificationService.getPreferences(...)`
 - `NotificationService.registerPushToken(...)`
+- `createPhase4ProofFeedUiFlow().reactToWorkout(...)`
+- `createPhase4ProofFeedUiFlow().commentOnWorkout(...)`
+- `createPhase4ProofFeedUiFlow().blockActor(...)`
+- `createPhase4ProofFeedUiFlow().reportContent(...)`
 
 ## DB migration hooks
 
@@ -33,3 +38,11 @@ Core methods:
 - `packages/db/supabase/migrations/202602190361_krux_beta_part3_s020.sql`
 
 These add `public.push_notification_tokens` with strict self-owned RLS.
+
+## Wiring expectations
+
+- Proof Feed screens should use `createPhase4ProofFeedUiFlow` for:
+  - stateful feed loading with blocked-actor filtering
+  - reaction/comment mutations that return refreshed snapshots
+  - moderation actions (`block`, `report`) with persisted records
+- Runtime wiring details: `docs/phase4-proof-feed-ui-wiring.md`.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -105,6 +105,13 @@
 77. Successful submit returns verification flags with `totalsUpdated=true`, `proofEventCreated=true`, `progressUpdated=true`.
 78. Missing post-submit signals return recoverable `WORKOUT_LOGGER_SIGNALS_INCOMPLETE` error.
 
+## Phase 4 Proof Feed UI
+
+79. `createPhase4ProofFeedUiFlow.load` filters blocked actor IDs from feed cards.
+80. `reactToWorkout` persists reaction state and returns refreshed snapshot.
+81. `commentOnWorkout` persists comment state and returns refreshed snapshot plus filtered thread.
+82. `reportContent` creates moderation record and includes it in refreshed `myReports`.
+
 ## Performance targets for pilot
 
 - Feed p95 load < 500ms for 50-card page.


### PR DESCRIPTION
## Summary
- add `createPhase4ProofFeedUiFlow` as the mobile Proof Feed UI controller
- wire interaction actions (`react`, `comment`) with refreshed server snapshot return
- wire moderation actions (`block`, `unblock`, `report`) and moderation record reflection
- enforce blocked-actor filtering on feed cards and workout interaction threads
- update mobile scaffold metadata and Phase 4 docs/runbook references

## Validation
- `apps/mobile/node_modules/.bin/tsc --noEmit -p apps/mobile/tsconfig.json`
- `bash packages/db/tests/run_smoke.sh`

## Acceptance coverage
- feed renders visible workouts via RLS + blocked-actor filtering
- reactions/comments persist and UI refreshes from server state
- blocked users are hidden from feed interactions and feed cards
- report actions create moderation records (`user_reports`)

Closes #6
