### PR TITLE
feat(phase5-admin): add ops console UI flow controller (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ Operational features are controlled by flags in `public.feature_flags`.
 
 - B2B admin ops service: `apps/admin/src/services/b2b-ops-service.ts`
 - B2B ops flow snapshot: `apps/admin/src/flows/phase5-b2b-ops.ts`
+- Ops console UI controller: `apps/admin/src/flows/phase5-ops-console-ui.ts`
 - Staff acceptance RPC migration set starts at: `packages/db/supabase/migrations/202602190364_krux_beta_part3_s023.sql`
 - Usage notes: `docs/phase5-runtime.md`
+- Screen wiring guide: `docs/phase5-ops-console-ui-wiring.md`
 
 ## Phase 6 Runtime
 

--- a/apps/admin/src/app/page.ts
+++ b/apps/admin/src/app/page.ts
@@ -1,6 +1,6 @@
 import { phase2StaffConsoleUiChecklist } from "../flows/phase2-staff-console-ui";
 import { phase6IntegrationMonitorChecklist } from "../flows/phase6-integration-monitor";
-import { phase5B2BOpsChecklist } from "../flows/phase5-b2b-ops";
+import { phase5OpsConsoleUiChecklist } from "../flows/phase5-ops-console-ui";
 import { phase8ComplianceOpsChecklist } from "../flows/phase8-compliance-ops";
 
 export function adminHomePageScaffold() {
@@ -30,21 +30,32 @@ export function adminHomePageScaffold() {
       ]
     },
     phase5: {
-      modules: [...phase5B2BOpsChecklist],
+      modules: [...phase5OpsConsoleUiChecklist],
+      screenFlow:
+        "class schedule -> bookings/waitlist -> check-in/access -> waiver/contract evidence -> refreshed snapshot",
+      recoverableErrors: [
+        "ADMIN_CLASS_CREATE_FAILED",
+        "ADMIN_CLASS_BOOKING_UPSERT_FAILED",
+        "ADMIN_CLASS_WAITLIST_UPDATE_FAILED",
+        "ADMIN_WAITLIST_PROMOTE_FAILED",
+        "ADMIN_CHECKIN_CREATE_FAILED",
+        "ADMIN_ACCESS_LOG_CREATE_FAILED",
+        "ADMIN_WAIVER_ACCEPTANCE_RECORD_FAILED",
+        "ADMIN_CONTRACT_ACCEPTANCE_RECORD_FAILED"
+      ],
       serviceSurface: [
-        "B2BOpsService.listMembershipPlans",
-        "B2BOpsService.createGymClass",
-        "B2BOpsService.listClassBookings",
-        "B2BOpsService.listClassWaitlist",
-        "B2BOpsService.promoteWaitlistMember",
-        "B2BOpsService.listWaivers",
-        "B2BOpsService.recordWaiverAcceptanceByStaff",
-        "B2BOpsService.listContracts",
-        "B2BOpsService.recordContractAcceptanceByStaff",
-        "B2BOpsService.recordCheckin",
-        "B2BOpsService.recordAccessLog",
+        "createPhase5OpsConsoleUiFlow.load",
+        "createPhase5OpsConsoleUiFlow.createClass",
+        "createPhase5OpsConsoleUiFlow.upsertClassBooking",
+        "createPhase5OpsConsoleUiFlow.promoteWaitlistMember",
+        "createPhase5OpsConsoleUiFlow.recordCheckinAndAccessLog",
+        "createPhase5OpsConsoleUiFlow.recordWaiverAcceptance",
+        "createPhase5OpsConsoleUiFlow.recordContractAcceptance",
         "B2BOpsService.listMemberSubscriptions",
-        "B2BOpsService.listInvoices"
+        "B2BOpsService.listInvoices",
+        "B2BOpsService.listPaymentTransactions",
+        "B2BOpsService.listRefunds",
+        "B2BOpsService.listDunningEvents"
       ]
     },
     phase6: {

--- a/apps/admin/src/flows/phase5-ops-console-ui.ts
+++ b/apps/admin/src/flows/phase5-ops-console-ui.ts
@@ -1,0 +1,353 @@
+import type {
+  AccessLog,
+  AdminRecordAcceptanceInput,
+  ClassBooking,
+  ContractAcceptance,
+  CreateGymClassInput,
+  GymCheckin,
+  GymClass,
+  RecordAccessLogInput,
+  RecordGymCheckinInput,
+  UpdateClassWaitlistInput,
+  UpdateGymClassInput,
+  UpsertClassBookingInput,
+  WaiverAcceptance
+} from "@kruxt/types";
+
+import { B2BOpsService, createAdminSupabaseClient, KruxtAdminError } from "../services";
+import {
+  createPhase5B2BOpsFlow,
+  phase5B2BOpsChecklist,
+  type Phase5B2BOpsLoadOptions,
+  type Phase5B2BOpsSnapshot
+} from "./phase5-b2b-ops";
+
+export type Phase5OpsUiStep =
+  | "class_management"
+  | "waitlist"
+  | "checkin_access"
+  | "waiver_contract"
+  | "billing_telemetry";
+
+export interface Phase5OpsUiError {
+  code: string;
+  step: Phase5OpsUiStep;
+  message: string;
+  recoverable: boolean;
+}
+
+export interface Phase5OpsLoadSuccess {
+  ok: true;
+  snapshot: Phase5B2BOpsSnapshot;
+}
+
+export interface Phase5OpsLoadFailure {
+  ok: false;
+  error: Phase5OpsUiError;
+}
+
+export type Phase5OpsLoadResult = Phase5OpsLoadSuccess | Phase5OpsLoadFailure;
+
+export interface Phase5OpsMutationSuccess {
+  ok: true;
+  action:
+    | "create_class"
+    | "update_class"
+    | "set_class_status"
+    | "upsert_booking"
+    | "update_booking_status"
+    | "update_waitlist"
+    | "promote_waitlist"
+    | "record_checkin_access"
+    | "record_waiver_acceptance"
+    | "record_contract_acceptance";
+  snapshot: Phase5B2BOpsSnapshot;
+  gymClass?: GymClass;
+  booking?: ClassBooking;
+  promotedBookingId?: string;
+  checkin?: GymCheckin;
+  accessLog?: AccessLog;
+  waiverAcceptanceId?: string;
+  waiverAcceptances?: WaiverAcceptance[];
+  contractAcceptanceId?: string;
+  contractAcceptances?: ContractAcceptance[];
+}
+
+export interface Phase5OpsMutationFailure {
+  ok: false;
+  error: Phase5OpsUiError;
+}
+
+export type Phase5OpsMutationResult = Phase5OpsMutationSuccess | Phase5OpsMutationFailure;
+
+export const phase5OpsConsoleUiChecklist = [
+  ...phase5B2BOpsChecklist,
+  "Manage classes and bookings from one operations surface",
+  "Promote waitlist and immediately refresh booking state",
+  "Record check-in/access, waiver, and contract evidence with auditable snapshots"
+] as const;
+
+function mapErrorStep(code: string): Phase5OpsUiStep {
+  if (code.includes("WAITLIST")) {
+    return "waitlist";
+  }
+
+  if (
+    code.includes("CLASS") ||
+    code.includes("BOOKING")
+  ) {
+    return "class_management";
+  }
+
+  if (code.includes("CHECKIN") || code.includes("ACCESS_LOG")) {
+    return "checkin_access";
+  }
+
+  if (code.includes("WAIVER") || code.includes("CONTRACT")) {
+    return "waiver_contract";
+  }
+
+  if (
+    code.includes("SUBSCRIPTION") ||
+    code.includes("INVOICE") ||
+    code.includes("PAYMENT") ||
+    code.includes("REFUND") ||
+    code.includes("DUNNING")
+  ) {
+    return "billing_telemetry";
+  }
+
+  return "class_management";
+}
+
+function mapErrorMessage(code: string, fallback: string): string {
+  if (code === "ADMIN_STAFF_ACCESS_DENIED") {
+    return "Staff access is required for gym operations actions.";
+  }
+
+  if (code === "ADMIN_AUTH_REQUIRED") {
+    return "Sign in is required before using staff operations.";
+  }
+
+  if (code === "ADMIN_WAITLIST_PROMOTE_NO_BOOKING") {
+    return "Promotion completed without booking confirmation. Refresh and retry.";
+  }
+
+  if (code === "ADMIN_WAIVER_ACCEPTANCE_NO_ID" || code === "ADMIN_CONTRACT_ACCEPTANCE_NO_ID") {
+    return "Acceptance was recorded without evidence id. Refresh evidence lists before proceeding.";
+  }
+
+  return fallback;
+}
+
+function mapUiError(error: unknown): Phase5OpsUiError {
+  const appError =
+    error instanceof KruxtAdminError
+      ? error
+      : new KruxtAdminError("ADMIN_PHASE5_ACTION_FAILED", "Unable to complete operations action.", error);
+
+  return {
+    code: appError.code,
+    step: mapErrorStep(appError.code),
+    message: mapErrorMessage(appError.code, appError.message),
+    recoverable: !["ADMIN_STAFF_ACCESS_DENIED", "ADMIN_AUTH_REQUIRED"].includes(appError.code)
+  };
+}
+
+export function createPhase5OpsConsoleUiFlow() {
+  const supabase = createAdminSupabaseClient();
+  const b2b = new B2BOpsService(supabase);
+  const baseFlow = createPhase5B2BOpsFlow();
+
+  const loadSnapshot = async (
+    gymId: string,
+    options: Phase5B2BOpsLoadOptions = {}
+  ): Promise<Phase5B2BOpsSnapshot> => baseFlow.load(gymId, options);
+
+  const runMutation = async (
+    gymId: string,
+    action: Phase5OpsMutationSuccess["action"],
+    mutate: () => Promise<Partial<Phase5OpsMutationSuccess>>,
+    options: Phase5B2BOpsLoadOptions = {}
+  ): Promise<Phase5OpsMutationResult> => {
+    try {
+      const payload = await mutate();
+      const snapshot = await loadSnapshot(gymId, options);
+
+      return {
+        ok: true,
+        action,
+        snapshot,
+        ...payload
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: mapUiError(error)
+      };
+    }
+  };
+
+  return {
+    checklist: [...phase5OpsConsoleUiChecklist],
+    load: async (gymId: string, options: Phase5B2BOpsLoadOptions = {}): Promise<Phase5OpsLoadResult> => {
+      try {
+        return {
+          ok: true,
+          snapshot: await loadSnapshot(gymId, options)
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    },
+    createClass: async (
+      gymId: string,
+      input: CreateGymClassInput
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(
+        gymId,
+        "create_class",
+        async () => {
+          const gymClass = await b2b.createGymClass(gymId, input);
+          return { gymClass };
+        },
+        { classId: undefined }
+      ),
+    updateClass: async (
+      gymId: string,
+      classId: string,
+      input: UpdateGymClassInput
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(
+        gymId,
+        "update_class",
+        async () => {
+          const gymClass = await b2b.updateGymClass(gymId, classId, input);
+          return { gymClass };
+        },
+        { classId }
+      ),
+    setClassStatus: async (
+      gymId: string,
+      classId: string,
+      status: GymClass["status"]
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(
+        gymId,
+        "set_class_status",
+        async () => {
+          const gymClass = await b2b.setGymClassStatus(gymId, classId, status);
+          return { gymClass };
+        },
+        { classId }
+      ),
+    upsertClassBooking: async (
+      gymId: string,
+      input: UpsertClassBookingInput
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(
+        gymId,
+        "upsert_booking",
+        async () => {
+          const booking = await b2b.upsertClassBookingByStaff(gymId, input);
+          return { booking };
+        },
+        { classId: input.classId }
+      ),
+    updateClassBookingStatus: async (
+      gymId: string,
+      bookingId: string,
+      status: ClassBooking["status"],
+      classIdForRefresh: string
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(
+        gymId,
+        "update_booking_status",
+        async () => {
+          const booking = await b2b.updateClassBookingStatus(gymId, bookingId, status);
+          return { booking };
+        },
+        { classId: classIdForRefresh }
+      ),
+    updateWaitlistEntry: async (
+      gymId: string,
+      waitlistEntryId: string,
+      input: UpdateClassWaitlistInput,
+      classIdForRefresh: string
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(
+        gymId,
+        "update_waitlist",
+        async () => {
+          await b2b.updateClassWaitlistEntry(gymId, waitlistEntryId, input);
+          return {};
+        },
+        { classId: classIdForRefresh }
+      ),
+    promoteWaitlistMember: async (gymId: string, classId: string): Promise<Phase5OpsMutationResult> =>
+      runMutation(
+        gymId,
+        "promote_waitlist",
+        async () => {
+          const promotedBookingId = await b2b.promoteWaitlistMember(gymId, classId);
+          return { promotedBookingId };
+        },
+        { classId }
+      ),
+    recordCheckinAndAccessLog: async (
+      gymId: string,
+      input: RecordGymCheckinInput,
+      accessLogOverride: Partial<RecordAccessLogInput> = {}
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(gymId, "record_checkin_access", async () => {
+        const checkin = await b2b.recordCheckin(gymId, input);
+        const accessLog = await b2b.recordAccessLog(gymId, {
+          userId: input.userId,
+          checkinId: checkin.id,
+          eventType: accessLogOverride.eventType ?? input.eventType,
+          result: accessLogOverride.result ?? input.result,
+          reason: accessLogOverride.reason,
+          metadata: {
+            source_channel: input.sourceChannel ?? "admin_panel",
+            ...(accessLogOverride.metadata ?? {})
+          }
+        });
+
+        return {
+          checkin,
+          accessLog
+        };
+      }),
+    recordWaiverAcceptance: async (
+      gymId: string,
+      waiverId: string,
+      input: AdminRecordAcceptanceInput
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(gymId, "record_waiver_acceptance", async () => {
+        const waiverAcceptanceId = await b2b.recordWaiverAcceptanceByStaff(gymId, waiverId, input);
+        const waiverAcceptances = await b2b.listWaiverAcceptances(gymId, waiverId, 200);
+
+        return {
+          waiverAcceptanceId,
+          waiverAcceptances
+        };
+      }),
+    recordContractAcceptance: async (
+      gymId: string,
+      contractId: string,
+      input: AdminRecordAcceptanceInput
+    ): Promise<Phase5OpsMutationResult> =>
+      runMutation(gymId, "record_contract_acceptance", async () => {
+        const contractAcceptanceId = await b2b.recordContractAcceptanceByStaff(gymId, contractId, input);
+        const contractAcceptances = await b2b.listContractAcceptances(gymId, contractId, 200);
+
+        return {
+          contractAcceptanceId,
+          contractAcceptances
+        };
+      })
+  };
+}

--- a/apps/admin/src/index.ts
+++ b/apps/admin/src/index.ts
@@ -3,5 +3,6 @@ export * from "./services";
 export * from "./flows/phase2-staff-ops";
 export * from "./flows/phase2-staff-console-ui";
 export * from "./flows/phase5-b2b-ops";
+export * from "./flows/phase5-ops-console-ui";
 export * from "./flows/phase6-integration-monitor";
 export * from "./flows/phase8-compliance-ops";

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -19,7 +19,7 @@
 2. Connect auth flow in mobile/admin to `profiles` creation, consent capture, guild hall load, and staff ops snapshot (`createPhase2OnboardingUiFlow` + `createPhase2StaffConsoleUiFlow`).
 3. Implement workout logger UI and call `log_workout_atomic` RPC (see `createPhase3WorkoutLoggerUiFlow`).
 4. Build feed UI from `createPhase4ProofFeedUiFlow` (`feed_events` + joined `workouts` + `social_interactions`).
-5. Connect admin UI screens to `createPhase5B2BOpsFlow` and `B2BOpsService`.
+5. Connect admin UI screens to `createPhase5OpsConsoleUiFlow` and `B2BOpsService`.
 6. Connect integration monitoring UI to `createPhase6IntegrationMonitorFlow`.
 7. Wire production provider credentials and scheduler cadence for `provider_webhook_ingest` + `sync_dispatcher`.
 8. Connect rank/trials UI to `createPhase7RankTrialsFlow` + `CompetitionService`.

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -6,7 +6,7 @@
 2. Verify smoke checks in target DB:
    - `packages/db/tests/rls_smoke.sql`
 3. Connect admin B2B screens to runtime flow:
-   - `createPhase5B2BOpsFlow`
+   - `createPhase5OpsConsoleUiFlow`
    - `B2BOpsService` methods for plans/classes/waitlist/waivers/contracts/check-ins
 4. Connect admin integration monitor screen:
    - `createPhase6IntegrationMonitorFlow`

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -12,6 +12,7 @@
 - Phase 4 runtime: social graph/feed ranking/notification service layer for mobile
 - Phase 4 mobile UI wiring: Proof Feed controller with interaction + moderation refresh loops
 - Phase 5 runtime: admin B2B ops service layer for classes, waitlist, waivers, contracts, check-ins, and billing telemetry
+- Phase 5 admin UI wiring: Ops Console controller with class/waitlist/check-in/acceptance mutation refresh loops
 - Phase 6 runtime: Apple/Garmin integration pipeline (mobile integration service + webhook ingest + sync dispatcher + cursor persistence)
 - Phase 6 monitoring runtime: admin integration health + sync failure monitor flow for gym staff
 - Phase 7 runtime: rank ladder + trials service layer with deterministic leaderboard recompute and challenge progress RPCs

--- a/docs/phase5-ops-console-ui-wiring.md
+++ b/docs/phase5-ops-console-ui-wiring.md
@@ -1,0 +1,50 @@
+# Phase 5 Ops Console UI Wiring
+
+Use `createPhase5OpsConsoleUiFlow` as the controller for B2B gym operations actions.
+
+## Operator screen sequence
+
+1. Load classes + booking/waitlist snapshot
+2. Create/update class and booking records
+3. Promote waitlist members
+4. Record check-in + access log evidence
+5. Record waiver/contract acceptances
+6. Render refreshed snapshot after each mutation
+
+## Runtime contract
+
+- `load(gymId, options?)`
+  - returns `{ ok: true, snapshot }` or `{ ok: false, error }`
+- `createClass(gymId, input)`
+- `updateClass(gymId, classId, input)`
+- `setClassStatus(gymId, classId, status)`
+- `upsertClassBooking(gymId, input)`
+- `updateClassBookingStatus(gymId, bookingId, status, classIdForRefresh)`
+- `updateWaitlistEntry(gymId, waitlistEntryId, input, classIdForRefresh)`
+- `promoteWaitlistMember(gymId, classId)`
+- `recordCheckinAndAccessLog(gymId, input, accessLogOverride?)`
+- `recordWaiverAcceptance(gymId, waiverId, input)`
+- `recordContractAcceptance(gymId, contractId, input)`
+
+All mutation methods return a refreshed `snapshot` so the console can render server-backed state with no extra request roundtrip.
+
+## Error handling
+
+Error shape:
+
+- `code`
+- `step` (`class_management`, `waitlist`, `checkin_access`, `waiver_contract`, `billing_telemetry`)
+- `message`
+- `recoverable`
+
+Recommended UI behavior:
+
+- if `recoverable = true`, keep the operator in the same module and show retry CTA
+- if `recoverable = false` (for example `ADMIN_STAFF_ACCESS_DENIED`), disable controls and route to unauthorized view
+
+## Acceptance mapping
+
+- Class create/update/status, booking upsert/update, and waitlist promotion all refresh the same snapshot contract.
+- Check-in recording always writes both `gym_checkins` and `checkins` evidence via one mutation.
+- Waiver/contract recording returns acceptance IDs plus refreshed evidence lists.
+- Staff access denials remain non-recoverable and block operational mutations.

--- a/docs/phase5-runtime.md
+++ b/docs/phase5-runtime.md
@@ -12,6 +12,7 @@ Phase 5 runtime now includes an admin service layer for B2B daily operations:
 
 - `apps/admin/src/services/b2b-ops-service.ts`
 - `apps/admin/src/flows/phase5-b2b-ops.ts`
+- `apps/admin/src/flows/phase5-ops-console-ui.ts`
 - `apps/admin/src/app/page.ts`
 
 Core methods:
@@ -29,6 +30,20 @@ Core methods:
 - `B2BOpsService.upsertMemberSubscription(...)`
 - `B2BOpsService.updateInvoice(...)`
 - `B2BOpsService.updateDunningEvent(...)`
+
+UI controller methods:
+
+- `createPhase5OpsConsoleUiFlow.load(...)`
+- `createPhase5OpsConsoleUiFlow.createClass(...)`
+- `createPhase5OpsConsoleUiFlow.upsertClassBooking(...)`
+- `createPhase5OpsConsoleUiFlow.promoteWaitlistMember(...)`
+- `createPhase5OpsConsoleUiFlow.recordCheckinAndAccessLog(...)`
+- `createPhase5OpsConsoleUiFlow.recordWaiverAcceptance(...)`
+- `createPhase5OpsConsoleUiFlow.recordContractAcceptance(...)`
+
+Wiring guide:
+
+- `docs/phase5-ops-console-ui-wiring.md`
 
 ## DB migration hooks
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -112,6 +112,14 @@
 81. `commentOnWorkout` persists comment state and returns refreshed snapshot plus filtered thread.
 82. `reportContent` creates moderation record and includes it in refreshed `myReports`.
 
+## Phase 5 Ops Console UI
+
+83. `createPhase5OpsConsoleUiFlow.load` returns class/bookings/waitlist/check-in/waiver/contract/billing snapshot in one call.
+84. `createClass`/`updateClass`/`setClassStatus` return refreshed snapshot with selected class state.
+85. `promoteWaitlistMember` returns booking id and refreshed booking/waitlist snapshot.
+86. `recordCheckinAndAccessLog` records both rows and returns refreshed operational snapshot.
+87. `recordWaiverAcceptance` and `recordContractAcceptance` return acceptance IDs plus refreshed evidence lists.
+
 ## Performance targets for pilot
 
 - Feed p95 load < 500ms for 50-card page.


### PR DESCRIPTION
## Summary
- add `createPhase5OpsConsoleUiFlow` as the admin controller for class management, waitlist, check-in/access, and waiver/contract acceptance actions
- return refreshed `Phase5B2BOpsSnapshot` after every mutation with step-scoped recoverable/non-recoverable UI errors
- wire Phase 5 UI flow into admin exports/scaffold metadata and add runtime + wiring + test-plan documentation updates

## Validation
- `apps/admin/node_modules/.bin/tsc --noEmit -p apps/admin/tsconfig.json`
- `bash packages/db/tests/run_smoke.sh`

Closes #7
