### PR TITLE
feat(phase6-mobile): add integrations UI activation flow (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ Operational features are controlled by flags in `public.feature_flags`.
 ## Phase 6 Runtime
 
 - Mobile integration runtime: `apps/mobile/src/services/integration-service.ts`, `apps/mobile/src/flows/phase6-integrations.ts`
+- Mobile integrations UI controller: `apps/mobile/src/flows/phase6-integrations-ui.ts`
 - Edge activation: `supabase/functions/provider_webhook_ingest`, `supabase/functions/sync_dispatcher`
 - Cursor + webhook sync migration set starts at: `packages/db/supabase/migrations/202602190370_krux_beta_part3_s029.sql`
 - Usage notes: `docs/phase6-runtime.md`
+- Screen wiring guide: `docs/phase6-integrations-ui-wiring.md`
 
 ## Phase 7 Runtime
 

--- a/apps/mobile/src/app.tsx
+++ b/apps/mobile/src/app.tsx
@@ -4,7 +4,7 @@ import { guildHallChecklist } from "./flows/guild-hall";
 import { phase2OnboardingChecklist } from "./flows/phase2-onboarding";
 import { phase3WorkoutLoggingChecklist } from "./flows/phase3-workout-logging";
 import { phase4SocialFeedChecklist } from "./flows/phase4-social-feed";
-import { phase6IntegrationsChecklist } from "./flows/phase6-integrations";
+import { phase6IntegrationsUiChecklist } from "./flows/phase6-integrations-ui";
 import { phase7RankTrialsChecklist } from "./flows/phase7-rank-trials";
 import { phase8PrivacyRequestsChecklist } from "./flows/phase8-privacy-requests";
 
@@ -80,7 +80,16 @@ export function mobileAppScaffold() {
     },
     phase6: {
       flow: "connect provider -> queue sync -> import activities -> persist cursor",
-      checklist: [...phase6IntegrationsChecklist],
+      screenFlow:
+        "provider selection -> connect/disconnect -> request sync -> validate imports/mapping -> activation report",
+      checklist: [...phase6IntegrationsUiChecklist],
+      recoverableErrors: [
+        "INTEGRATION_CONNECTION_UPSERT_FAILED",
+        "INTEGRATION_CONNECTION_STATUS_UPDATE_FAILED",
+        "INTEGRATION_SYNC_JOB_QUEUE_FAILED",
+        "INTEGRATION_CONNECTION_INACTIVE",
+        "INTEGRATION_IMPORTS_READ_FAILED"
+      ],
       activeProviders: ["apple_health", "garmin"],
       darkLaunchProviders: ["fitbit", "huawei_health", "suunto", "oura", "whoop"],
       tables: [
@@ -90,7 +99,13 @@ export function mobileAppScaffold() {
         "external_activity_imports",
         "integration_webhook_events"
       ],
-      edgeFunctions: ["provider_webhook_ingest", "sync_dispatcher"]
+      edgeFunctions: ["provider_webhook_ingest", "sync_dispatcher"],
+      activationSurface: [
+        "createPhase6IntegrationsUiFlow.connectProvider",
+        "createPhase6IntegrationsUiFlow.disconnectProvider",
+        "createPhase6IntegrationsUiFlow.queueSync",
+        "createPhase6IntegrationsUiFlow.validateActivation"
+      ]
     },
     phase7: {
       flow: "load weekly rank ladders -> load trials -> submit challenge progress -> weekly recompute",

--- a/apps/mobile/src/flows/phase6-integrations-ui.ts
+++ b/apps/mobile/src/flows/phase6-integrations-ui.ts
@@ -1,0 +1,484 @@
+import type {
+  DeviceConnection,
+  DeviceSyncCursor,
+  DeviceSyncJob,
+  ExternalActivityImport,
+  IntegrationProvider,
+  QueueDeviceSyncJobInput
+} from "@kruxt/types";
+
+import { createMobileSupabaseClient, IntegrationService, KruxtAppError } from "../services";
+import {
+  createPhase6IntegrationsFlow,
+  phase6IntegrationsChecklist,
+  type Phase6IntegrationsSnapshot
+} from "./phase6-integrations";
+
+const activeIntegrationProviders = ["apple_health", "garmin"] as const;
+
+export type ActiveIntegrationProvider = (typeof activeIntegrationProviders)[number];
+
+export type Phase6IntegrationsUiStep =
+  | "provider_selection"
+  | "connection_management"
+  | "sync_queue"
+  | "import_mapping";
+
+export interface Phase6ImportDuplicateGroup {
+  provider: ActiveIntegrationProvider;
+  externalActivityId: string;
+  count: number;
+}
+
+export interface Phase6ProviderState {
+  provider: ActiveIntegrationProvider;
+  connection: DeviceConnection | null;
+  latestSyncJob: DeviceSyncJob | null;
+  cursor: DeviceSyncCursor | null;
+  importsTotal: number;
+  mappedImports: number;
+  unmappedImports: number;
+  duplicateExternalActivityIds: string[];
+  latestImportAt: string | null;
+}
+
+export interface Phase6IntegrationsUiSnapshot {
+  providers: ActiveIntegrationProvider[];
+  connections: DeviceConnection[];
+  syncJobs: DeviceSyncJob[];
+  syncCursors: DeviceSyncCursor[];
+  imports: ExternalActivityImport[];
+  providerStates: Phase6ProviderState[];
+  duplicateImportGroups: Phase6ImportDuplicateGroup[];
+  hiddenUnsupportedConnectionCount: number;
+  hiddenUnsupportedImportCount: number;
+  mappedImportCount: number;
+  unmappedImportCount: number;
+}
+
+export interface Phase6IntegrationsUiError {
+  code: string;
+  step: Phase6IntegrationsUiStep;
+  message: string;
+  recoverable: boolean;
+}
+
+export interface Phase6IntegrationsLoadSuccess {
+  ok: true;
+  snapshot: Phase6IntegrationsUiSnapshot;
+}
+
+export interface Phase6IntegrationsLoadFailure {
+  ok: false;
+  error: Phase6IntegrationsUiError;
+}
+
+export type Phase6IntegrationsLoadResult = Phase6IntegrationsLoadSuccess | Phase6IntegrationsLoadFailure;
+
+export interface Phase6IntegrationsMutationSuccess {
+  ok: true;
+  action: "connect_provider" | "disconnect_provider" | "queue_sync";
+  provider: ActiveIntegrationProvider;
+  snapshot: Phase6IntegrationsUiSnapshot;
+  connection?: DeviceConnection;
+  syncJob?: DeviceSyncJob;
+}
+
+export interface Phase6IntegrationsMutationFailure {
+  ok: false;
+  error: Phase6IntegrationsUiError;
+}
+
+export type Phase6IntegrationsMutationResult =
+  | Phase6IntegrationsMutationSuccess
+  | Phase6IntegrationsMutationFailure;
+
+export interface Phase6ActivationReport {
+  requiredProviders: ActiveIntegrationProvider[];
+  connectedProviders: ActiveIntegrationProvider[];
+  missingProviders: ActiveIntegrationProvider[];
+  queuedOrRunningSyncJobCount: number;
+  duplicateImportGroups: Phase6ImportDuplicateGroup[];
+  mappedImportCount: number;
+  unmappedImportCount: number;
+  mappingCoverage: number;
+  ready: boolean;
+}
+
+export interface Phase6ActivationValidationSuccess {
+  ok: true;
+  snapshot: Phase6IntegrationsUiSnapshot;
+  report: Phase6ActivationReport;
+}
+
+export interface Phase6ActivationValidationFailure {
+  ok: false;
+  error: Phase6IntegrationsUiError;
+}
+
+export type Phase6ActivationValidationResult =
+  | Phase6ActivationValidationSuccess
+  | Phase6ActivationValidationFailure;
+
+export interface ConnectProviderInput {
+  providerUserId?: string | null;
+  scopes?: string[];
+  accessTokenEncrypted?: string | null;
+  refreshTokenEncrypted?: string | null;
+  tokenExpiresAt?: string | null;
+  metadata?: Record<string, unknown>;
+  queueInitialSync?: boolean;
+  initialSyncCursor?: Record<string, unknown>;
+}
+
+export const phase6IntegrationsUiChecklist = [
+  ...phase6IntegrationsChecklist,
+  "Connect/disconnect Apple Health and Garmin providers",
+  "Queue sync jobs and refresh connector state",
+  "Validate duplicate-safe activity imports and workout mapping coverage"
+] as const;
+
+function isActiveProvider(provider: IntegrationProvider): provider is ActiveIntegrationProvider {
+  return (activeIntegrationProviders as readonly IntegrationProvider[]).includes(provider);
+}
+
+function assertActiveProvider(provider: IntegrationProvider): ActiveIntegrationProvider {
+  if (!isActiveProvider(provider)) {
+    throw new KruxtAppError(
+      "INTEGRATION_PROVIDER_UNSUPPORTED",
+      "Only Apple Health and Garmin connectors are active in this beta."
+    );
+  }
+
+  return provider;
+}
+
+function mapErrorStep(code: string): Phase6IntegrationsUiStep {
+  if (code === "INTEGRATION_PROVIDER_UNSUPPORTED") {
+    return "provider_selection";
+  }
+
+  if (code.includes("SYNC_JOB") || code.includes("CURSOR")) {
+    return "sync_queue";
+  }
+
+  if (code.includes("IMPORT") || code.includes("DUPLICATE")) {
+    return "import_mapping";
+  }
+
+  if (code.includes("CONNECTION")) {
+    return "connection_management";
+  }
+
+  return "provider_selection";
+}
+
+function mapErrorMessage(code: string, fallback: string): string {
+  if (code === "INTEGRATION_PROVIDER_UNSUPPORTED") {
+    return "Only Apple Health and Garmin are available in this beta.";
+  }
+
+  if (code === "INTEGRATION_CONNECTION_NOT_FOUND") {
+    return "Provider connection not found. Connect the provider first.";
+  }
+
+  if (code === "INTEGRATION_CONNECTION_INACTIVE") {
+    return "Reconnect the provider before requesting a sync.";
+  }
+
+  if (code === "INTEGRATION_SYNC_JOB_QUEUE_FAILED") {
+    return "Sync request failed. Retry after refreshing provider status.";
+  }
+
+  return fallback;
+}
+
+function mapUiError(error: unknown): Phase6IntegrationsUiError {
+  const appError =
+    error instanceof KruxtAppError
+      ? error
+      : new KruxtAppError("INTEGRATIONS_UI_ACTION_FAILED", "Unable to complete integration action.", error);
+
+  return {
+    code: appError.code,
+    step: mapErrorStep(appError.code),
+    message: mapErrorMessage(appError.code, appError.message),
+    recoverable: appError.code !== "INTEGRATION_PROVIDER_UNSUPPORTED"
+  };
+}
+
+function mapDuplicateGroups(
+  provider: ActiveIntegrationProvider,
+  imports: ExternalActivityImport[]
+): Phase6ImportDuplicateGroup[] {
+  const counts = new Map<string, number>();
+
+  for (const imported of imports) {
+    const key = imported.externalActivityId.trim();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const duplicates: Phase6ImportDuplicateGroup[] = [];
+  for (const [externalActivityId, count] of counts.entries()) {
+    if (count > 1) {
+      duplicates.push({
+        provider,
+        externalActivityId,
+        count
+      });
+    }
+  }
+
+  duplicates.sort((left, right) => left.externalActivityId.localeCompare(right.externalActivityId));
+  return duplicates;
+}
+
+function buildUiSnapshot(snapshot: Phase6IntegrationsSnapshot): Phase6IntegrationsUiSnapshot {
+  const connections = snapshot.connections.filter((connection) => isActiveProvider(connection.provider));
+  const syncJobs = snapshot.syncJobs.filter((job) => isActiveProvider(job.provider));
+  const syncCursors = snapshot.syncCursors.filter((cursor) => isActiveProvider(cursor.provider));
+  const imports = snapshot.imports.filter((imported) => isActiveProvider(imported.provider));
+
+  const providerStates: Phase6ProviderState[] = [];
+  const duplicateImportGroups: Phase6ImportDuplicateGroup[] = [];
+
+  for (const provider of activeIntegrationProviders) {
+    const connection = connections.find((row) => row.provider === provider) ?? null;
+    const providerSyncJobs = syncJobs.filter((row) => row.provider === provider);
+    const providerImports = imports.filter((row) => row.provider === provider);
+    const providerDuplicates = mapDuplicateGroups(provider, providerImports);
+    const mappedImports = providerImports.filter((row) => Boolean(row.mappedWorkoutId)).length;
+    const latestImportAt = providerImports[0]?.importedAt ?? null;
+
+    duplicateImportGroups.push(...providerDuplicates);
+    providerStates.push({
+      provider,
+      connection,
+      latestSyncJob: providerSyncJobs[0] ?? null,
+      cursor: connection
+        ? syncCursors.find((row) => row.connectionId === connection.id && row.provider === provider) ?? null
+        : null,
+      importsTotal: providerImports.length,
+      mappedImports,
+      unmappedImports: providerImports.length - mappedImports,
+      duplicateExternalActivityIds: providerDuplicates.map((row) => row.externalActivityId),
+      latestImportAt
+    });
+  }
+
+  return {
+    providers: [...activeIntegrationProviders],
+    connections,
+    syncJobs,
+    syncCursors,
+    imports,
+    providerStates,
+    duplicateImportGroups,
+    hiddenUnsupportedConnectionCount: snapshot.connections.length - connections.length,
+    hiddenUnsupportedImportCount: snapshot.imports.length - imports.length,
+    mappedImportCount: providerStates.reduce((total, row) => total + row.mappedImports, 0),
+    unmappedImportCount: providerStates.reduce((total, row) => total + row.unmappedImports, 0)
+  };
+}
+
+function buildActivationReport(snapshot: Phase6IntegrationsUiSnapshot): Phase6ActivationReport {
+  const connectedProviders = snapshot.providerStates
+    .filter((row) => row.connection?.status === "active")
+    .map((row) => row.provider);
+  const missingProviders = activeIntegrationProviders.filter((provider) => !connectedProviders.includes(provider));
+  const queuedOrRunningSyncJobCount = snapshot.syncJobs.filter((job) =>
+    ["queued", "running", "retry_scheduled"].includes(job.status)
+  ).length;
+  const totalImports = snapshot.mappedImportCount + snapshot.unmappedImportCount;
+
+  return {
+    requiredProviders: [...activeIntegrationProviders],
+    connectedProviders,
+    missingProviders,
+    queuedOrRunningSyncJobCount,
+    duplicateImportGroups: snapshot.duplicateImportGroups,
+    mappedImportCount: snapshot.mappedImportCount,
+    unmappedImportCount: snapshot.unmappedImportCount,
+    mappingCoverage: totalImports > 0 ? snapshot.mappedImportCount / totalImports : 1,
+    ready:
+      missingProviders.length === 0 &&
+      snapshot.duplicateImportGroups.length === 0 &&
+      queuedOrRunningSyncJobCount === 0
+  };
+}
+
+export function createPhase6IntegrationsUiFlow() {
+  const supabase = createMobileSupabaseClient();
+  const integrations = new IntegrationService(supabase);
+  const baseFlow = createPhase6IntegrationsFlow();
+
+  const loadSnapshot = async (
+    userId: string,
+    provider?: IntegrationProvider
+  ): Promise<Phase6IntegrationsUiSnapshot> => {
+    if (provider) {
+      assertActiveProvider(provider);
+    }
+
+    const snapshot = await baseFlow.load(userId, provider);
+    return buildUiSnapshot(snapshot);
+  };
+
+  const runMutation = async (
+    userId: string,
+    provider: ActiveIntegrationProvider,
+    action: Phase6IntegrationsMutationSuccess["action"],
+    mutate: () => Promise<Partial<Phase6IntegrationsMutationSuccess>>
+  ): Promise<Phase6IntegrationsMutationResult> => {
+    try {
+      const payload = await mutate();
+      const snapshot = await loadSnapshot(userId, provider);
+
+      return {
+        ok: true,
+        action,
+        provider,
+        snapshot,
+        ...payload
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: mapUiError(error)
+      };
+    }
+  };
+
+  return {
+    checklist: [...phase6IntegrationsUiChecklist],
+    activeProviders: [...activeIntegrationProviders],
+    load: async (userId: string, provider?: IntegrationProvider): Promise<Phase6IntegrationsLoadResult> => {
+      try {
+        return {
+          ok: true,
+          snapshot: await loadSnapshot(userId, provider)
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    },
+    connectProvider: async (
+      userId: string,
+      provider: IntegrationProvider,
+      input: ConnectProviderInput = {}
+    ): Promise<Phase6IntegrationsMutationResult> => {
+      try {
+        const activeProvider = assertActiveProvider(provider);
+
+        return await runMutation(userId, activeProvider, "connect_provider", async () => {
+          const connection = await integrations.upsertConnection(userId, {
+            provider: activeProvider,
+            status: "active",
+            providerUserId: input.providerUserId,
+            scopes: input.scopes,
+            accessTokenEncrypted: input.accessTokenEncrypted,
+            refreshTokenEncrypted: input.refreshTokenEncrypted,
+            tokenExpiresAt: input.tokenExpiresAt,
+            metadata: input.metadata
+          });
+
+          let syncJob: DeviceSyncJob | undefined;
+          if (input.queueInitialSync !== false) {
+            syncJob = await integrations.queueSyncJob(userId, {
+              connectionId: connection.id,
+              jobType: "pull_activities",
+              cursor: input.initialSyncCursor ?? {}
+            });
+          }
+
+          return {
+            provider: activeProvider,
+            connection,
+            syncJob
+          };
+        });
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    },
+    disconnectProvider: async (
+      userId: string,
+      provider: IntegrationProvider
+    ): Promise<Phase6IntegrationsMutationResult> => {
+      try {
+        const activeProvider = assertActiveProvider(provider);
+
+        return await runMutation(userId, activeProvider, "disconnect_provider", async () => {
+          const connections = await integrations.listConnections(userId, activeProvider, 5);
+          const target = connections.find((row) => row.status === "active") ?? connections[0];
+
+          if (!target) {
+            throw new KruxtAppError("INTEGRATION_CONNECTION_NOT_FOUND", "Provider connection not found.");
+          }
+
+          const connection = await integrations.updateConnectionStatus(userId, target.id, "revoked");
+
+          return {
+            provider: activeProvider,
+            connection
+          };
+        });
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    },
+    queueSync: async (
+      userId: string,
+      input: QueueDeviceSyncJobInput
+    ): Promise<Phase6IntegrationsMutationResult> => {
+      try {
+        const connections = await integrations.listConnections(userId, undefined, 50);
+        const connection = connections.find((row) => row.id === input.connectionId);
+        if (!connection) {
+          throw new KruxtAppError("INTEGRATION_CONNECTION_NOT_FOUND", "Provider connection not found.");
+        }
+
+        const activeProvider = assertActiveProvider(connection.provider);
+
+        return runMutation(userId, activeProvider, "queue_sync", async () => {
+          const syncJob = await integrations.queueSyncJob(userId, input);
+
+          return {
+            provider: activeProvider,
+            connection,
+            syncJob
+          };
+        });
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    },
+    validateActivation: async (userId: string): Promise<Phase6ActivationValidationResult> => {
+      try {
+        const snapshot = await loadSnapshot(userId);
+        return {
+          ok: true,
+          snapshot,
+          report: buildActivationReport(snapshot)
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    }
+  };
+}

--- a/apps/mobile/src/index.ts
+++ b/apps/mobile/src/index.ts
@@ -8,5 +8,6 @@ export * from "./flows/phase3-workout-logger-ui";
 export * from "./flows/phase4-social-feed";
 export * from "./flows/phase4-proof-feed-ui";
 export * from "./flows/phase6-integrations";
+export * from "./flows/phase6-integrations-ui";
 export * from "./flows/phase7-rank-trials";
 export * from "./flows/phase8-privacy-requests";

--- a/docs/implementation-roadmap.md
+++ b/docs/implementation-roadmap.md
@@ -7,6 +7,7 @@
 - Edge function entrypoints scaffolded for integrations, rankings, compliance, and audit
 - Phase 5 runtime scaffolded: B2B ops service + flow for gym admin operations
 - Phase 6 runtime scaffolded: integration service + Apple/Garmin webhook/sync activation path
+- Phase 6 mobile UI scaffolded: connector activation flow with sync/idempotency/mapping validation
 - Phase 6 monitoring scaffolded: gym staff integration health and sync failure monitor flow
 - Phase 7 runtime scaffolded: challenge/trials service + rank ladder flow + hardened leaderboard recompute
 - Phase 8 runtime slice 1 scaffolded: privacy request mobile/admin flows + queue processor + status transition RPCs
@@ -21,10 +22,11 @@
 4. Build feed UI from `createPhase4ProofFeedUiFlow` (`feed_events` + joined `workouts` + `social_interactions`).
 5. Connect admin UI screens to `createPhase5OpsConsoleUiFlow` and `B2BOpsService`.
 6. Connect integration monitoring UI to `createPhase6IntegrationMonitorFlow`.
-7. Wire production provider credentials and scheduler cadence for `provider_webhook_ingest` + `sync_dispatcher`.
-8. Connect rank/trials UI to `createPhase7RankTrialsFlow` + `CompetitionService`.
-9. Validate weekly rank recompute scheduler (`.github/workflows/rank-recompute-weekly.yml`) and alert routing.
-10. Run privacy workflows (`submit_privacy_request`) and staff handling pipeline (`transition_privacy_request_status`).
+7. Connect mobile integration screens to `createPhase6IntegrationsUiFlow` + `IntegrationService`.
+8. Wire production provider credentials and scheduler cadence for `provider_webhook_ingest` + `sync_dispatcher`.
+9. Connect rank/trials UI to `createPhase7RankTrialsFlow` + `CompetitionService`.
+10. Validate weekly rank recompute scheduler (`.github/workflows/rank-recompute-weekly.yml`) and alert routing.
+11. Run privacy workflows (`submit_privacy_request`) and staff handling pipeline (`transition_privacy_request_status`).
 
 ## Feature flag activation policy
 

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -12,7 +12,7 @@
    - `createPhase6IntegrationMonitorFlow`
    - `IntegrationMonitorService` health + sync-failure records
 5. Connect mobile integration screens to runtime flow:
-   - `createPhase6IntegrationsFlow`
+   - `createPhase6IntegrationsUiFlow`
    - `IntegrationService` methods for provider linking, sync queueing, and import snapshots
 6. Connect mobile Rank Ladder + Trials screens:
    - `createPhase7RankTrialsFlow`

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -14,6 +14,7 @@
 - Phase 5 runtime: admin B2B ops service layer for classes, waitlist, waivers, contracts, check-ins, and billing telemetry
 - Phase 5 admin UI wiring: Ops Console controller with class/waitlist/check-in/acceptance mutation refresh loops
 - Phase 6 runtime: Apple/Garmin integration pipeline (mobile integration service + webhook ingest + sync dispatcher + cursor persistence)
+- Phase 6 mobile UI wiring: connector controller with provider activation, sync queueing, and mapping/idempotency validation
 - Phase 6 monitoring runtime: admin integration health + sync failure monitor flow for gym staff
 - Phase 7 runtime: rank ladder + trials service layer with deterministic leaderboard recompute and challenge progress RPCs
 - Phase 7 ops follow-up: weekly rank recompute scheduler workflow + deterministic repeat probes + failure issue alerts

--- a/docs/phase6-integrations-ui-wiring.md
+++ b/docs/phase6-integrations-ui-wiring.md
@@ -1,0 +1,53 @@
+# Phase 6 Integrations UI Wiring
+
+Use `createPhase6IntegrationsUiFlow` as the single mobile controller for Apple Health and Garmin activation.
+
+## Screen sequence
+
+1. Provider selection (`apple_health`, `garmin`)
+2. Connect/disconnect provider
+3. Queue sync job for connected provider
+4. Render imported activity + mapping telemetry
+5. Validate activation readiness report
+
+## Runtime contract
+
+- `load(userId, provider?)`
+  - returns `{ ok: true, snapshot }` or `{ ok: false, error }`
+- `connectProvider(userId, provider, input?)`
+- `disconnectProvider(userId, provider)`
+- `queueSync(userId, { connectionId, jobType?, cursor?, sourceWebhookEventId? })`
+- `validateActivation(userId)`
+
+All mutation methods return refreshed snapshot state so the UI can reconcile connections, sync jobs, and imports without extra fetch calls.
+
+## Snapshot highlights
+
+- `providerStates` includes per-provider connection state, latest sync job, cursor, and mapped/unmapped import counts.
+- `duplicateImportGroups` exposes any `(provider, externalActivityId)` collisions for idempotency validation.
+- `mappedImportCount` and `unmappedImportCount` expose end-to-end activity-to-workout mapping progress.
+- `hiddenUnsupportedConnectionCount`/`hiddenUnsupportedImportCount` hide dark-launched providers in UI while preserving telemetry visibility.
+
+## Activation validation report
+
+`validateActivation(userId)` returns:
+
+- `connectedProviders` and `missingProviders` for Apple/Garmin readiness
+- `queuedOrRunningSyncJobCount` backlog signal
+- `duplicateImportGroups` idempotency signal
+- `mappingCoverage` ratio (`mapped / total imports`)
+- `ready` boolean (`all providers connected`, `no duplicate groups`, `no queued/running backlog`)
+
+## Error handling
+
+Error shape:
+
+- `code`
+- `step` (`provider_selection`, `connection_management`, `sync_queue`, `import_mapping`)
+- `message`
+- `recoverable`
+
+Recommended UI behavior:
+
+- if `recoverable = true`, stay in current module and show retry CTA
+- if `recoverable = false` (`INTEGRATION_PROVIDER_UNSUPPORTED`), restrict provider selector to active connectors only

--- a/docs/phase6-runtime.md
+++ b/docs/phase6-runtime.md
@@ -11,6 +11,7 @@ Phase 6 runtime now includes integration activation for Apple + Garmin with dark
 
 - `apps/mobile/src/services/integration-service.ts`
 - `apps/mobile/src/flows/phase6-integrations.ts`
+- `apps/mobile/src/flows/phase6-integrations-ui.ts`
 - `apps/mobile/src/app.tsx`
 
 Core methods:
@@ -21,6 +22,18 @@ Core methods:
 - `IntegrationService.listSyncJobs(...)`
 - `IntegrationService.getSyncCursor(...)`
 - `IntegrationService.listImportedActivities(...)`
+
+UI controller methods:
+
+- `createPhase6IntegrationsUiFlow.load(...)`
+- `createPhase6IntegrationsUiFlow.connectProvider(...)`
+- `createPhase6IntegrationsUiFlow.disconnectProvider(...)`
+- `createPhase6IntegrationsUiFlow.queueSync(...)`
+- `createPhase6IntegrationsUiFlow.validateActivation(...)`
+
+Wiring guide:
+
+- `docs/phase6-integrations-ui-wiring.md`
 
 ## Admin monitoring entrypoints
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -120,6 +120,14 @@
 86. `recordCheckinAndAccessLog` records both rows and returns refreshed operational snapshot.
 87. `recordWaiverAcceptance` and `recordContractAcceptance` return acceptance IDs plus refreshed evidence lists.
 
+## Phase 6 Integrations UI
+
+88. `createPhase6IntegrationsUiFlow.load` returns only active beta providers (`apple_health`, `garmin`) plus per-provider state summaries.
+89. `connectProvider` upserts active provider connection, queues initial sync job, and returns refreshed snapshot.
+90. `disconnectProvider` sets provider connection to `revoked` and returns refreshed snapshot.
+91. `queueSync` rejects inactive connections and refreshes snapshot after successful queue.
+92. `validateActivation` reports missing providers, sync backlog, duplicate import groups, and deterministic mapping coverage.
+
 ## Performance targets for pilot
 
 - Feed p95 load < 500ms for 50-card page.


### PR DESCRIPTION
## Summary
- add `createPhase6IntegrationsUiFlow` to activate Apple/Garmin mobile connector UX with connect, disconnect, sync queueing, and activation validation
- add duplicate-import and mapped/unmapped workout telemetry in UI snapshot to support idempotency + activity mapping acceptance
- wire mobile scaffold exports/docs/test plan to the new Phase 6 UI controller and runtime contract

## Validation
- `apps/mobile/node_modules/.bin/tsc --noEmit -p apps/mobile/tsconfig.json`
- `bash packages/db/tests/run_smoke.sh`

Closes #8
