### PR TITLE
feat(phase5): mobile guild hall split-view flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Operational features are controlled by flags in `public.feature_flags`.
 - B2B admin ops service: `apps/admin/src/services/b2b-ops-service.ts`
 - B2B ops flow snapshot: `apps/admin/src/flows/phase5-b2b-ops.ts`
 - Ops console UI controller: `apps/admin/src/flows/phase5-ops-console-ui.ts`
+- Mobile guild hall split-view UI controller: `apps/mobile/src/flows/phase5-guild-hall-ui.ts`
+- Mobile guild hall service contract surface: `apps/mobile/src/services/gym-service.ts`
 - Staff acceptance RPC migration set starts at: `packages/db/supabase/migrations/202602190364_krux_beta_part3_s023.sql`
 - Usage notes: `docs/phase5-runtime.md`
 - Screen wiring guide: `docs/phase5-ops-console-ui-wiring.md`

--- a/apps/mobile/src/app.tsx
+++ b/apps/mobile/src/app.tsx
@@ -4,6 +4,7 @@ import { guildHallChecklist } from "./flows/guild-hall";
 import { phase2OnboardingChecklist } from "./flows/phase2-onboarding";
 import { phase3WorkoutLoggingChecklist } from "./flows/phase3-workout-logging";
 import { phase4SocialFeedChecklist } from "./flows/phase4-social-feed";
+import { phase5GuildHallUiChecklist } from "./flows/phase5-guild-hall-ui";
 import { phase6IntegrationsUiChecklist } from "./flows/phase6-integrations-ui";
 import { phase7RankTrialsChecklist } from "./flows/phase7-rank-trials";
 import { phase8PrivacyRequestsChecklist } from "./flows/phase8-privacy-requests";
@@ -80,6 +81,31 @@ export function mobileAppScaffold() {
         "push_notification_tokens"
       ],
       featureFlags: ["public_feed_boost_enabled"]
+    },
+    phase5: {
+      flow: "role-aware guild hall -> member status surface + staff operations board",
+      screenFlow:
+        "member status (membership/classes/waitlist/check-ins/compliance) -> conditional staff operations board",
+      checklist: [...phase5GuildHallUiChecklist],
+      modules: ["GuildHallMemberView", "GuildHallStaffView"],
+      tables: [
+        "gym_memberships",
+        "gym_membership_plans",
+        "gym_classes",
+        "class_bookings",
+        "class_waitlist",
+        "gym_checkins",
+        "access_logs",
+        "waivers",
+        "contracts",
+        "waiver_acceptances",
+        "contract_acceptances"
+      ],
+      uiSurface: ["createPhase5GuildHallUiFlow.load", "createPhase5GuildHallUiFlow.getStaffConfirmDialog"],
+      guardrails: [
+        "member surfaces never expose staff mutations",
+        "staff controls always require explicit confirm dialogs"
+      ]
     },
     phase6: {
       flow: "connect provider -> queue sync -> import activities -> persist cursor",

--- a/apps/mobile/src/flows/phase5-guild-hall-ui.ts
+++ b/apps/mobile/src/flows/phase5-guild-hall-ui.ts
@@ -1,0 +1,472 @@
+import type {
+  AccessLog,
+  ClassBooking,
+  ClassWaitlistEntry,
+  Contract,
+  GymCheckin,
+  GymClass,
+  GymMembership,
+  GymMembershipPlan,
+  GuildHallSnapshot,
+  GuildRosterMember,
+  Waiver
+} from "@kruxt/types";
+
+import {
+  createMobileSupabaseClient,
+  GymService,
+  KruxtAppError,
+  type GymStaffOpsSnapshot
+} from "../services";
+
+export type Phase5GuildHallUiStep = "member_overview" | "staff_overview";
+export type GuildHallViewMode = "member" | "staff";
+export type GuildHallComplianceKind = "waiver" | "contract";
+export type GuildHallStaffControlKey =
+  | "promote_waitlist_member"
+  | "resolve_checkin_anomaly"
+  | "record_waiver_acceptance"
+  | "record_contract_acceptance";
+
+export interface Phase5GuildHallUiLoadOptions {
+  classId?: string;
+  rosterLimit?: number;
+}
+
+export interface GuildHallComplianceStatusItem {
+  id: string;
+  title: string;
+  policyVersion: string;
+  documentUrl: string;
+  accepted: boolean;
+  acceptedAt?: string;
+  kind: GuildHallComplianceKind;
+}
+
+export interface GuildHallStaffClassPressure {
+  classId: string;
+  title: string;
+  startsAt: string;
+  capacity: number;
+  bookedCount: number;
+  waitlistCount: number;
+  pressure: "low" | "medium" | "high";
+}
+
+export interface GuildHallCheckinAnomaly {
+  accessLogId: string;
+  eventType: AccessLog["eventType"];
+  result: AccessLog["result"];
+  createdAt: string;
+  reason?: string | null;
+}
+
+export interface GuildHallStaffControl {
+  key: GuildHallStaffControlKey;
+  label: string;
+  description: string;
+  requiresConfirm: true;
+  enabled: boolean;
+}
+
+export interface GuildHallStaffConfirmDialog {
+  title: string;
+  message: string;
+  confirmLabel: string;
+}
+
+export interface GuildHallStaffBoard {
+  operationsToday: {
+    classesScheduled: number;
+    selectedClassBookings: number;
+    selectedClassWaitlist: number;
+    pendingApprovals: number;
+    unresolvedWaiverTasks: number;
+    unresolvedContractTasks: number;
+  };
+  capacityPressure: GuildHallStaffClassPressure[];
+  checkinAnomalies: GuildHallCheckinAnomaly[];
+  opsSnapshot: {
+    classes: GymClass[];
+    selectedClassId?: string;
+    selectedClassBookings: ClassBooking[];
+    selectedClassWaitlist: ClassWaitlistEntry[];
+    recentCheckins: GymCheckin[];
+    recentAccessLogs: AccessLog[];
+    waivers: Waiver[];
+    contracts: Contract[];
+  };
+}
+
+export interface Phase5GuildHallUiMicrocopy {
+  proofFirst: string;
+  rosterRule: string;
+  staffGuardrail: string;
+}
+
+export interface Phase5GuildHallUiSnapshot {
+  viewMode: GuildHallViewMode;
+  guild: GuildHallSnapshot;
+  roster: GuildRosterMember[];
+  membership: GymMembership | null;
+  membershipPlan: GymMembershipPlan | null;
+  upcomingClasses: GymClass[];
+  waitlistEntries: ClassWaitlistEntry[];
+  recentCheckins: GymCheckin[];
+  waiverStatus: GuildHallComplianceStatusItem[];
+  contractStatus: GuildHallComplianceStatusItem[];
+  staffBoard: GuildHallStaffBoard | null;
+  staffControls: GuildHallStaffControl[];
+  microcopy: Phase5GuildHallUiMicrocopy;
+}
+
+export interface Phase5GuildHallUiError {
+  code: string;
+  step: Phase5GuildHallUiStep;
+  message: string;
+  recoverable: boolean;
+}
+
+export interface Phase5GuildHallLoadSuccess {
+  ok: true;
+  snapshot: Phase5GuildHallUiSnapshot;
+}
+
+export interface Phase5GuildHallLoadFailure {
+  ok: false;
+  error: Phase5GuildHallUiError;
+}
+
+export type Phase5GuildHallLoadResult = Phase5GuildHallLoadSuccess | Phase5GuildHallLoadFailure;
+
+const DEFAULT_ROSTER_LIMIT = 60;
+const MAX_CAPACITY_PRESSURE_CLASSES = 20;
+
+const PHASE5_GUILD_HALL_MICROCOPY: Phase5GuildHallUiMicrocopy = {
+  proofFirst: "Proof first.",
+  rosterRule: "Roster updates weekly.",
+  staffGuardrail: "Staff controls require explicit confirmation."
+};
+
+const PHASE5_STAFF_CONFIRM_DIALOGS: Record<GuildHallStaffControlKey, GuildHallStaffConfirmDialog> = {
+  promote_waitlist_member: {
+    title: "Confirm waitlist promotion",
+    message: "Promoting from waitlist changes class occupancy immediately. Confirm to continue.",
+    confirmLabel: "Promote now"
+  },
+  resolve_checkin_anomaly: {
+    title: "Confirm anomaly resolution",
+    message: "Resolving a check-in anomaly writes an auditable operations event. Confirm to continue.",
+    confirmLabel: "Resolve anomaly"
+  },
+  record_waiver_acceptance: {
+    title: "Confirm waiver evidence",
+    message: "Recording waiver acceptance creates immutable legal evidence. Confirm member identity first.",
+    confirmLabel: "Record waiver"
+  },
+  record_contract_acceptance: {
+    title: "Confirm contract evidence",
+    message: "Recording contract acceptance creates immutable legal evidence. Confirm member identity first.",
+    confirmLabel: "Record contract"
+  }
+};
+
+export const phase5GuildHallUiChecklist = [
+  "Load role-aware guild hall snapshot",
+  "Render member status for classes, waitlist, check-ins, waivers, and contracts",
+  "Render staff operations board with class pressure and anomaly visibility",
+  "Keep staff controls confirmation-gated and hidden for member-only users"
+] as const;
+
+function mapErrorStep(code: string): Phase5GuildHallUiStep {
+  if (code.includes("STAFF") || code.includes("ACCESS_LOG") || code.includes("PENDING_APPROVALS")) {
+    return "staff_overview";
+  }
+  return "member_overview";
+}
+
+function mapErrorMessage(code: string, fallback: string): string {
+  if (code === "GUILD_STAFF_REQUIRED") {
+    return "Staff controls are locked for non-staff members.";
+  }
+
+  if (code === "GUILD_STAFF_INACTIVE") {
+    return "Staff controls are unavailable because your staff membership is inactive.";
+  }
+
+  if (code === "GUILD_MEMBERSHIP_REQUIRED") {
+    return "Join a guild before opening Guild Hall operations.";
+  }
+
+  return fallback;
+}
+
+function mapUiError(error: unknown): Phase5GuildHallUiError {
+  const appError =
+    error instanceof KruxtAppError
+      ? error
+      : new KruxtAppError("GUILD_HALL_UI_LOAD_FAILED", "Unable to load Guild Hall.", error);
+
+  return {
+    code: appError.code,
+    step: mapErrorStep(appError.code),
+    message: mapErrorMessage(appError.code, appError.message),
+    recoverable: appError.code !== "AUTH_REQUIRED"
+  };
+}
+
+function buildWaiverStatus(waivers: Waiver[], acceptedWaiverIds: Map<string, string>): GuildHallComplianceStatusItem[] {
+  return waivers.map((waiver) => ({
+    id: waiver.id,
+    title: waiver.title,
+    policyVersion: waiver.policyVersion,
+    documentUrl: waiver.documentUrl,
+    accepted: acceptedWaiverIds.has(waiver.id),
+    acceptedAt: acceptedWaiverIds.get(waiver.id),
+    kind: "waiver"
+  }));
+}
+
+function buildContractStatus(
+  contracts: Contract[],
+  acceptedContractIds: Map<string, string>
+): GuildHallComplianceStatusItem[] {
+  return contracts.map((contract) => ({
+    id: contract.id,
+    title: contract.title,
+    policyVersion: contract.policyVersion,
+    documentUrl: contract.documentUrl,
+    accepted: acceptedContractIds.has(contract.id),
+    acceptedAt: acceptedContractIds.get(contract.id),
+    kind: "contract"
+  }));
+}
+
+function calculatePressure(
+  gymClass: GymClass,
+  bookings: ClassBooking[],
+  waitlist: ClassWaitlistEntry[]
+): GuildHallStaffClassPressure {
+  const bookedCount = bookings.filter((row) => row.status === "booked" || row.status === "attended").length;
+  const waitlistCount = waitlist.filter((row) => row.status === "pending" || row.status === "promoted").length;
+  const occupancyRatio = gymClass.capacity > 0 ? bookedCount / gymClass.capacity : 1;
+
+  let pressure: GuildHallStaffClassPressure["pressure"] = "low";
+  if (occupancyRatio >= 0.95 || waitlistCount > 0) {
+    pressure = "high";
+  } else if (occupancyRatio >= 0.75) {
+    pressure = "medium";
+  }
+
+  return {
+    classId: gymClass.id,
+    title: gymClass.title,
+    startsAt: gymClass.startsAt,
+    capacity: gymClass.capacity,
+    bookedCount,
+    waitlistCount,
+    pressure
+  };
+}
+
+async function buildStaffBoard(
+  gyms: GymService,
+  gymId: string,
+  staffSnapshot: GymStaffOpsSnapshot,
+  waivers: Waiver[],
+  contracts: Contract[]
+): Promise<GuildHallStaffBoard> {
+  const classesForPressure = staffSnapshot.classes.slice(0, MAX_CAPACITY_PRESSURE_CLASSES);
+  const pressureRows = await Promise.all(
+    classesForPressure.map(async (gymClass) => {
+      const [bookings, waitlist] = await Promise.all([
+        gyms.listClassBookings(gymId, gymClass.id, 500),
+        gyms.listClassWaitlist(gymId, gymClass.id, 500)
+      ]);
+
+      return calculatePressure(gymClass, bookings, waitlist);
+    })
+  );
+
+  const checkinAnomalies: GuildHallCheckinAnomaly[] = staffSnapshot.recentAccessLogs
+    .filter((row) => row.result === "denied" || row.result === "override_allowed")
+    .slice(0, 30)
+    .map((row) => ({
+      accessLogId: row.id,
+      eventType: row.eventType,
+      result: row.result,
+      createdAt: row.createdAt,
+      reason: row.reason
+    }));
+
+  return {
+    operationsToday: {
+      classesScheduled: staffSnapshot.classes.length,
+      selectedClassBookings: staffSnapshot.selectedClassBookings.length,
+      selectedClassWaitlist: staffSnapshot.selectedClassWaitlist.length,
+      pendingApprovals: staffSnapshot.pendingApprovals,
+      unresolvedWaiverTasks: staffSnapshot.complianceTasks.unresolvedWaiverTasks,
+      unresolvedContractTasks: staffSnapshot.complianceTasks.unresolvedContractTasks
+    },
+    capacityPressure: pressureRows.sort((left, right) => left.startsAt.localeCompare(right.startsAt)),
+    checkinAnomalies,
+    opsSnapshot: {
+      classes: staffSnapshot.classes,
+      selectedClassId: staffSnapshot.selectedClassId,
+      selectedClassBookings: staffSnapshot.selectedClassBookings,
+      selectedClassWaitlist: staffSnapshot.selectedClassWaitlist,
+      recentCheckins: staffSnapshot.recentCheckins,
+      recentAccessLogs: staffSnapshot.recentAccessLogs,
+      waivers,
+      contracts
+    }
+  };
+}
+
+function buildStaffControls(staffBoard: GuildHallStaffBoard | null): GuildHallStaffControl[] {
+  if (!staffBoard) {
+    return [];
+  }
+
+  return [
+    {
+      key: "promote_waitlist_member",
+      label: "Promote waitlist member",
+      description: "Advance first pending athlete to booking.",
+      requiresConfirm: true,
+      enabled: staffBoard.operationsToday.selectedClassWaitlist > 0
+    },
+    {
+      key: "resolve_checkin_anomaly",
+      label: "Resolve check-in anomaly",
+      description: "Review denied and override access logs.",
+      requiresConfirm: true,
+      enabled: staffBoard.checkinAnomalies.length > 0
+    },
+    {
+      key: "record_waiver_acceptance",
+      label: "Record waiver acceptance",
+      description: "Capture member waiver evidence from staff console.",
+      requiresConfirm: true,
+      enabled: staffBoard.operationsToday.unresolvedWaiverTasks > 0
+    },
+    {
+      key: "record_contract_acceptance",
+      label: "Record contract acceptance",
+      description: "Capture member contract evidence from staff console.",
+      requiresConfirm: true,
+      enabled: staffBoard.operationsToday.unresolvedContractTasks > 0
+    }
+  ];
+}
+
+export function createPhase5GuildHallUiFlow() {
+  const supabase = createMobileSupabaseClient();
+  const gyms = new GymService(supabase);
+
+  const loadSnapshot = async (
+    userId: string,
+    options: Phase5GuildHallUiLoadOptions = {}
+  ): Promise<Phase5GuildHallUiSnapshot> => {
+    const guild = await gyms.getGuildHallSnapshot(userId);
+    const rosterLimit = options.rosterLimit ?? DEFAULT_ROSTER_LIMIT;
+
+    if (!guild.gymId) {
+      return {
+        viewMode: "member",
+        guild,
+        roster: [],
+        membership: null,
+        membershipPlan: null,
+        upcomingClasses: [],
+        waitlistEntries: [],
+        recentCheckins: [],
+        waiverStatus: [],
+        contractStatus: [],
+        staffBoard: null,
+        staffControls: [],
+        microcopy: { ...PHASE5_GUILD_HALL_MICROCOPY }
+      };
+    }
+
+    const [roster, membership, upcomingClasses, waitlistEntries, recentCheckins, waivers, contracts] =
+      await Promise.all([
+        gyms.listGuildRoster(guild.gymId, rosterLimit),
+        gyms.getMembershipForGymUser(guild.gymId, userId),
+        gyms.listUpcomingClassesForMember(guild.gymId, userId, 20),
+        gyms.listWaitlistEntriesForMember(guild.gymId, userId, 20),
+        gyms.listRecentCheckinsForMember(guild.gymId, userId, 20),
+        gyms.listActiveWaivers(guild.gymId),
+        gyms.listActiveContracts(guild.gymId)
+      ]);
+
+    const [waiverAcceptances, contractAcceptances] = await Promise.all([
+      gyms.listMyWaiverAcceptances(userId, waivers.map((waiver) => waiver.id)),
+      gyms.listMyContractAcceptances(userId, contracts.map((contract) => contract.id))
+    ]);
+
+    const waiverAcceptedById = new Map<string, string>();
+    for (const acceptance of waiverAcceptances) {
+      if (!waiverAcceptedById.has(acceptance.waiverId)) {
+        waiverAcceptedById.set(acceptance.waiverId, acceptance.acceptedAt);
+      }
+    }
+
+    const contractAcceptedById = new Map<string, string>();
+    for (const acceptance of contractAcceptances) {
+      if (!contractAcceptedById.has(acceptance.contractId)) {
+        contractAcceptedById.set(acceptance.contractId, acceptance.acceptedAt);
+      }
+    }
+
+    const membershipPlan =
+      membership?.membershipPlanId && guild.gymId
+        ? await gyms.getMembershipPlan(guild.gymId, membership.membershipPlanId)
+        : null;
+
+    let staffBoard: GuildHallStaffBoard | null = null;
+    if (guild.isStaff) {
+      const staffSnapshot = await gyms.loadStaffOpsSnapshot(guild.gymId, userId, options.classId);
+      staffBoard = await buildStaffBoard(gyms, guild.gymId, staffSnapshot, waivers, contracts);
+    }
+
+    return {
+      viewMode: guild.isStaff ? "staff" : "member",
+      guild,
+      roster,
+      membership,
+      membershipPlan,
+      upcomingClasses,
+      waitlistEntries,
+      recentCheckins,
+      waiverStatus: buildWaiverStatus(waivers, waiverAcceptedById),
+      contractStatus: buildContractStatus(contracts, contractAcceptedById),
+      staffBoard,
+      staffControls: buildStaffControls(staffBoard),
+      microcopy: { ...PHASE5_GUILD_HALL_MICROCOPY }
+    };
+  };
+
+  return {
+    checklist: [...phase5GuildHallUiChecklist],
+    microcopy: { ...PHASE5_GUILD_HALL_MICROCOPY },
+    getStaffConfirmDialog: (controlKey: GuildHallStaffControlKey): GuildHallStaffConfirmDialog =>
+      PHASE5_STAFF_CONFIRM_DIALOGS[controlKey],
+    load: async (
+      userId: string,
+      options: Phase5GuildHallUiLoadOptions = {}
+    ): Promise<Phase5GuildHallLoadResult> => {
+      try {
+        return {
+          ok: true,
+          snapshot: await loadSnapshot(userId, options)
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    }
+  };
+}

--- a/apps/mobile/src/index.ts
+++ b/apps/mobile/src/index.ts
@@ -7,6 +7,7 @@ export * from "./flows/phase3-workout-logging";
 export * from "./flows/phase3-workout-logger-ui";
 export * from "./flows/phase4-social-feed";
 export * from "./flows/phase4-proof-feed-ui";
+export * from "./flows/phase5-guild-hall-ui";
 export * from "./flows/phase6-integrations";
 export * from "./flows/phase6-integrations-ui";
 export * from "./flows/phase7-rank-trials";

--- a/apps/mobile/src/services/gym-service.ts
+++ b/apps/mobile/src/services/gym-service.ts
@@ -1,15 +1,25 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
+  AccessLog,
+  ClassBooking,
+  ClassWaitlistEntry,
+  Contract,
+  ContractAcceptance,
   CreateGymInput,
+  GymCheckin,
+  GymClass,
   GuildHallSnapshot,
   GuildRole,
   GuildRosterMember,
   Gym,
   GymMembership,
+  GymMembershipPlan,
   GymRole,
   JoinGymInput,
   MembershipStatus,
-  RankTier
+  RankTier,
+  Waiver,
+  WaiverAcceptance
 } from "@kruxt/types";
 
 import { KruxtAppError, throwIfError } from "./errors";
@@ -58,6 +68,163 @@ type GuildRosterProfileRow = {
   rank_tier: RankTier | null;
 };
 
+type GymMembershipPlanRow = {
+  id: string;
+  gym_id: string;
+  name: string;
+  billing_cycle: GymMembershipPlan["billingCycle"];
+  price_cents: number;
+  currency: string;
+  class_credits_per_cycle: number | null;
+  trial_days: number | null;
+  cancel_policy: string | null;
+  provider_product_id: string | null;
+  provider_price_id: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+type GymClassRow = {
+  id: string;
+  gym_id: string;
+  coach_user_id: string | null;
+  title: string;
+  description: string | null;
+  capacity: number;
+  status: GymClass["status"];
+  starts_at: string;
+  ends_at: string;
+  booking_opens_at: string | null;
+  booking_closes_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type ClassBookingRow = {
+  id: string;
+  class_id: string;
+  user_id: string;
+  status: ClassBooking["status"];
+  booked_at: string;
+  checked_in_at: string | null;
+  source_channel: string;
+  updated_at: string;
+};
+
+type ClassWaitlistRow = {
+  id: string;
+  class_id: string;
+  user_id: string;
+  position: number;
+  status: ClassWaitlistEntry["status"];
+  notified_at: string | null;
+  expires_at: string | null;
+  promoted_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type GymCheckinRow = {
+  id: string;
+  gym_id: string;
+  user_id: string;
+  membership_id: string | null;
+  class_id: string | null;
+  event_type: GymCheckin["eventType"];
+  result: GymCheckin["result"];
+  source_channel: string;
+  note: string | null;
+  checked_in_at: string;
+  created_by: string | null;
+  created_at: string;
+};
+
+type AccessLogRow = {
+  id: string;
+  gym_id: string;
+  user_id: string | null;
+  checkin_id: string | null;
+  event_type: AccessLog["eventType"];
+  result: AccessLog["result"];
+  reason: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  created_by: string | null;
+};
+
+type WaiverRow = {
+  id: string;
+  gym_id: string;
+  title: string;
+  policy_version: string;
+  language_code: string;
+  document_url: string;
+  is_active: boolean;
+  effective_at: string;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type WaiverAcceptanceRow = {
+  id: string;
+  waiver_id: string;
+  user_id: string;
+  gym_membership_id: string | null;
+  accepted_at: string;
+  source: string;
+  locale: string | null;
+  signature_data: Record<string, unknown>;
+  created_at: string;
+};
+
+type ContractRow = {
+  id: string;
+  gym_id: string;
+  title: string;
+  contract_type: string;
+  policy_version: string;
+  language_code: string;
+  document_url: string;
+  is_active: boolean;
+  effective_at: string;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type ContractAcceptanceRow = {
+  id: string;
+  contract_id: string;
+  user_id: string;
+  gym_membership_id: string | null;
+  accepted_at: string;
+  source: string;
+  locale: string | null;
+  signature_data: Record<string, unknown>;
+  created_at: string;
+};
+
+export interface GymComplianceTaskCounts {
+  activeMembers: number;
+  activeWaivers: number;
+  activeContracts: number;
+  unresolvedWaiverTasks: number;
+  unresolvedContractTasks: number;
+}
+
+export interface GymStaffOpsSnapshot {
+  classes: GymClass[];
+  selectedClassId?: string;
+  selectedClassBookings: ClassBooking[];
+  selectedClassWaitlist: ClassWaitlistEntry[];
+  recentCheckins: GymCheckin[];
+  recentAccessLogs: AccessLog[];
+  pendingApprovals: number;
+  complianceTasks: GymComplianceTaskCounts;
+}
+
 function mapGym(row: GymRow): Gym {
   return {
     id: row.id,
@@ -85,6 +252,164 @@ function mapMembership(row: GymMembershipRow): GymMembership {
     membershipPlanId: row.membership_plan_id,
     startedAt: row.started_at,
     endsAt: row.ends_at
+  };
+}
+
+function mapPlan(row: GymMembershipPlanRow): GymMembershipPlan {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    name: row.name,
+    billingCycle: row.billing_cycle,
+    priceCents: row.price_cents,
+    currency: row.currency,
+    classCreditsPerCycle: row.class_credits_per_cycle,
+    trialDays: row.trial_days,
+    cancelPolicy: row.cancel_policy,
+    providerProductId: row.provider_product_id,
+    providerPriceId: row.provider_price_id,
+    isActive: row.is_active,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapClass(row: GymClassRow): GymClass {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    coachUserId: row.coach_user_id,
+    title: row.title,
+    description: row.description,
+    capacity: row.capacity,
+    status: row.status,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    bookingOpensAt: row.booking_opens_at,
+    bookingClosesAt: row.booking_closes_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapBooking(row: ClassBookingRow): ClassBooking {
+  return {
+    id: row.id,
+    classId: row.class_id,
+    userId: row.user_id,
+    status: row.status,
+    bookedAt: row.booked_at,
+    checkedInAt: row.checked_in_at,
+    sourceChannel: row.source_channel,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapWaitlist(row: ClassWaitlistRow): ClassWaitlistEntry {
+  return {
+    id: row.id,
+    classId: row.class_id,
+    userId: row.user_id,
+    position: row.position,
+    status: row.status,
+    notifiedAt: row.notified_at,
+    expiresAt: row.expires_at,
+    promotedAt: row.promoted_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapCheckin(row: GymCheckinRow): GymCheckin {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    userId: row.user_id,
+    membershipId: row.membership_id,
+    classId: row.class_id,
+    eventType: row.event_type,
+    result: row.result,
+    sourceChannel: row.source_channel,
+    note: row.note,
+    checkedInAt: row.checked_in_at,
+    createdBy: row.created_by,
+    createdAt: row.created_at
+  };
+}
+
+function mapAccessLog(row: AccessLogRow): AccessLog {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    userId: row.user_id,
+    checkinId: row.checkin_id,
+    eventType: row.event_type,
+    result: row.result,
+    reason: row.reason,
+    metadata: row.metadata ?? {},
+    createdAt: row.created_at,
+    createdBy: row.created_by
+  };
+}
+
+function mapWaiver(row: WaiverRow): Waiver {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    title: row.title,
+    policyVersion: row.policy_version,
+    languageCode: row.language_code,
+    documentUrl: row.document_url,
+    isActive: row.is_active,
+    effectiveAt: row.effective_at,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapWaiverAcceptance(row: WaiverAcceptanceRow): WaiverAcceptance {
+  return {
+    id: row.id,
+    waiverId: row.waiver_id,
+    userId: row.user_id,
+    gymMembershipId: row.gym_membership_id,
+    acceptedAt: row.accepted_at,
+    source: row.source,
+    locale: row.locale,
+    signatureData: row.signature_data ?? {},
+    createdAt: row.created_at
+  };
+}
+
+function mapContract(row: ContractRow): Contract {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    title: row.title,
+    contractType: row.contract_type,
+    policyVersion: row.policy_version,
+    languageCode: row.language_code,
+    documentUrl: row.document_url,
+    isActive: row.is_active,
+    effectiveAt: row.effective_at,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapContractAcceptance(row: ContractAcceptanceRow): ContractAcceptance {
+  return {
+    id: row.id,
+    contractId: row.contract_id,
+    userId: row.user_id,
+    gymMembershipId: row.gym_membership_id,
+    acceptedAt: row.accepted_at,
+    source: row.source,
+    locale: row.locale,
+    signatureData: row.signature_data ?? {},
+    createdAt: row.created_at
   };
 }
 
@@ -134,6 +459,32 @@ function rankRole(role: GymRole): number {
     default:
       return 4;
   }
+}
+
+function isActiveMembership(status: MembershipStatus): boolean {
+  return status === "active" || status === "trial";
+}
+
+function sortMembershipRows(rows: GymMembershipRow[]): GymMembershipRow[] {
+  return [...rows].sort((a, b) => {
+    const statusRank = rankMembershipStatus(a.membership_status) - rankMembershipStatus(b.membership_status);
+    if (statusRank !== 0) {
+      return statusRank;
+    }
+
+    return rankRole(a.role) - rankRole(b.role);
+  });
+}
+
+function utcDayBounds(date: Date): { start: string; end: string } {
+  const startDate = new Date(date);
+  startDate.setUTCHours(0, 0, 0, 0);
+  const endDate = new Date(startDate);
+  endDate.setUTCDate(endDate.getUTCDate() + 1);
+  return {
+    start: startDate.toISOString(),
+    end: endDate.toISOString()
+  };
 }
 
 export class GymService {
@@ -276,6 +627,19 @@ export class GymService {
     return (data as GymMembershipRow[]).map(mapMembership);
   }
 
+  async getPrimaryMembership(userId: string): Promise<GymMembership | null> {
+    const { data, error } = await this.supabase
+      .from("gym_memberships")
+      .select("*")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false });
+
+    throwIfError(error, "MEMBERSHIP_LIST_FAILED", "Unable to load memberships.");
+
+    const memberships = sortMembershipRows((data as GymMembershipRow[]) ?? []);
+    return memberships[0] ? mapMembership(memberships[0]) : null;
+  }
+
   async getGuildHallSnapshot(userId: string): Promise<GuildHallSnapshot> {
     const { data: profileData, error: profileError } = await this.supabase
       .from("profiles")
@@ -293,14 +657,7 @@ export class GymService {
 
     throwIfError(membershipError, "GUILD_HALL_MEMBERSHIPS_FAILED", "Unable to load memberships for Guild Hall.");
 
-    const memberships = (membershipData as GymMembershipRow[]).sort((a, b) => {
-      const statusRank = rankMembershipStatus(a.membership_status) - rankMembershipStatus(b.membership_status);
-      if (statusRank !== 0) {
-        return statusRank;
-      }
-
-      return rankRole(a.role) - rankRole(b.role);
-    });
+    const memberships = sortMembershipRows((membershipData as GymMembershipRow[]) ?? []);
 
     const primary = memberships[0];
     const profile = profileData as GuildHallProfileRow | null;
@@ -441,5 +798,424 @@ export class GymService {
       });
 
     return rosterMembers;
+  }
+
+  async getMembershipPlan(gymId: string, membershipPlanId: string): Promise<GymMembershipPlan | null> {
+    const { data, error } = await this.supabase
+      .from("gym_membership_plans")
+      .select("*")
+      .eq("gym_id", gymId)
+      .eq("id", membershipPlanId)
+      .maybeSingle();
+
+    throwIfError(error, "GYM_MEMBERSHIP_PLAN_READ_FAILED", "Unable to load membership plan.");
+
+    return data ? mapPlan(data as GymMembershipPlanRow) : null;
+  }
+
+  async listUpcomingClassesForMember(gymId: string, userId: string, limit = 20): Promise<GymClass[]> {
+    const { data: bookingData, error: bookingError } = await this.supabase
+      .from("class_bookings")
+      .select("class_id,status,booked_at")
+      .eq("user_id", userId)
+      .in("status", ["booked", "waitlisted"])
+      .order("booked_at", { ascending: false })
+      .limit(Math.max(limit * 4, 40));
+
+    throwIfError(bookingError, "GUILD_MEMBER_BOOKINGS_FAILED", "Unable to load class bookings.");
+
+    const bookingRows = ((bookingData as Array<{ class_id: string }>) ?? []).filter(
+      (row) => typeof row.class_id === "string" && row.class_id.length > 0
+    );
+    if (bookingRows.length === 0) {
+      return [];
+    }
+
+    const classIds = Array.from(new Set(bookingRows.map((row) => row.class_id)));
+    const { data: classData, error: classError } = await this.supabase
+      .from("gym_classes")
+      .select("*")
+      .eq("gym_id", gymId)
+      .in("id", classIds)
+      .eq("status", "scheduled")
+      .gte("starts_at", new Date().toISOString())
+      .order("starts_at", { ascending: true })
+      .limit(Math.max(limit, 20));
+
+    throwIfError(classError, "GUILD_MEMBER_CLASSES_FAILED", "Unable to load upcoming classes.");
+
+    return ((classData as GymClassRow[]) ?? []).map(mapClass).slice(0, limit);
+  }
+
+  async listWaitlistEntriesForMember(gymId: string, userId: string, limit = 20): Promise<ClassWaitlistEntry[]> {
+    const { data: waitlistData, error: waitlistError } = await this.supabase
+      .from("class_waitlist")
+      .select("*")
+      .eq("user_id", userId)
+      .in("status", ["pending", "promoted"])
+      .order("created_at", { ascending: false })
+      .limit(Math.max(limit * 4, 40));
+
+    throwIfError(waitlistError, "GUILD_MEMBER_WAITLIST_FAILED", "Unable to load waitlist status.");
+
+    const waitlistRows = (waitlistData as ClassWaitlistRow[]) ?? [];
+    if (waitlistRows.length === 0) {
+      return [];
+    }
+
+    const classIds = Array.from(new Set(waitlistRows.map((row) => row.class_id)));
+    const { data: classData, error: classError } = await this.supabase
+      .from("gym_classes")
+      .select("id,gym_id,status,starts_at")
+      .eq("gym_id", gymId)
+      .in("id", classIds)
+      .eq("status", "scheduled")
+      .gte("starts_at", new Date().toISOString());
+
+    throwIfError(classError, "GUILD_MEMBER_WAITLIST_CLASS_FAILED", "Unable to resolve waitlist classes.");
+
+    const allowedClassIds = new Set(
+      ((classData as Array<{ id: string }>) ?? []).map((row) => row.id).filter(Boolean)
+    );
+
+    return waitlistRows
+      .filter((row) => allowedClassIds.has(row.class_id))
+      .sort((left, right) => {
+        if (left.position !== right.position) {
+          return left.position - right.position;
+        }
+        return left.created_at.localeCompare(right.created_at);
+      })
+      .map(mapWaitlist)
+      .slice(0, limit);
+  }
+
+  async listRecentCheckinsForMember(gymId: string, userId: string, limit = 20): Promise<GymCheckin[]> {
+    const { data, error } = await this.supabase
+      .from("gym_checkins")
+      .select("*")
+      .eq("gym_id", gymId)
+      .eq("user_id", userId)
+      .order("checked_in_at", { ascending: false })
+      .limit(limit);
+
+    throwIfError(error, "GUILD_MEMBER_CHECKINS_FAILED", "Unable to load recent check-ins.");
+
+    return ((data as GymCheckinRow[]) ?? []).map(mapCheckin);
+  }
+
+  async listRecentCheckins(gymId: string, limit = 150): Promise<GymCheckin[]> {
+    const { data, error } = await this.supabase
+      .from("gym_checkins")
+      .select("*")
+      .eq("gym_id", gymId)
+      .order("checked_in_at", { ascending: false })
+      .limit(limit);
+
+    throwIfError(error, "GUILD_STAFF_CHECKINS_FAILED", "Unable to load gym check-ins.");
+
+    return ((data as GymCheckinRow[]) ?? []).map(mapCheckin);
+  }
+
+  async listActiveWaivers(gymId: string): Promise<Waiver[]> {
+    const { data, error } = await this.supabase
+      .from("waivers")
+      .select("*")
+      .eq("gym_id", gymId)
+      .eq("is_active", true)
+      .order("effective_at", { ascending: false });
+
+    throwIfError(error, "GUILD_WAIVERS_READ_FAILED", "Unable to load waivers.");
+
+    return ((data as WaiverRow[]) ?? []).map(mapWaiver);
+  }
+
+  async listActiveContracts(gymId: string): Promise<Contract[]> {
+    const { data, error } = await this.supabase
+      .from("contracts")
+      .select("*")
+      .eq("gym_id", gymId)
+      .eq("is_active", true)
+      .order("effective_at", { ascending: false });
+
+    throwIfError(error, "GUILD_CONTRACTS_READ_FAILED", "Unable to load contracts.");
+
+    return ((data as ContractRow[]) ?? []).map(mapContract);
+  }
+
+  async listMyWaiverAcceptances(userId: string, waiverIds: string[], limit = 200): Promise<WaiverAcceptance[]> {
+    if (waiverIds.length === 0) {
+      return [];
+    }
+
+    const { data, error } = await this.supabase
+      .from("waiver_acceptances")
+      .select("*")
+      .eq("user_id", userId)
+      .in("waiver_id", waiverIds)
+      .order("accepted_at", { ascending: false })
+      .limit(limit);
+
+    throwIfError(error, "GUILD_WAIVER_ACCEPTANCES_READ_FAILED", "Unable to load waiver acceptances.");
+
+    return ((data as WaiverAcceptanceRow[]) ?? []).map(mapWaiverAcceptance);
+  }
+
+  async listMyContractAcceptances(userId: string, contractIds: string[], limit = 200): Promise<ContractAcceptance[]> {
+    if (contractIds.length === 0) {
+      return [];
+    }
+
+    const { data, error } = await this.supabase
+      .from("contract_acceptances")
+      .select("*")
+      .eq("user_id", userId)
+      .in("contract_id", contractIds)
+      .order("accepted_at", { ascending: false })
+      .limit(limit);
+
+    throwIfError(error, "GUILD_CONTRACT_ACCEPTANCES_READ_FAILED", "Unable to load contract acceptances.");
+
+    return ((data as ContractAcceptanceRow[]) ?? []).map(mapContractAcceptance);
+  }
+
+  async listTodayClasses(gymId: string, date = new Date(), limit = 120): Promise<GymClass[]> {
+    const bounds = utcDayBounds(date);
+
+    const { data, error } = await this.supabase
+      .from("gym_classes")
+      .select("*")
+      .eq("gym_id", gymId)
+      .eq("status", "scheduled")
+      .gte("starts_at", bounds.start)
+      .lt("starts_at", bounds.end)
+      .order("starts_at", { ascending: true })
+      .limit(limit);
+
+    throwIfError(error, "GUILD_STAFF_CLASSES_FAILED", "Unable to load today's classes.");
+
+    return ((data as GymClassRow[]) ?? []).map(mapClass);
+  }
+
+  async listClassBookings(gymId: string, classId: string, limit = 300): Promise<ClassBooking[]> {
+    const { data: gymClass, error: classError } = await this.supabase
+      .from("gym_classes")
+      .select("id,gym_id")
+      .eq("id", classId)
+      .maybeSingle();
+
+    throwIfError(classError, "GUILD_STAFF_CLASS_LOOKUP_FAILED", "Unable to resolve class.");
+
+    if (!gymClass || (gymClass as { gym_id: string }).gym_id !== gymId) {
+      throw new KruxtAppError("GUILD_STAFF_CLASS_NOT_FOUND", "Class not found for this gym.");
+    }
+
+    const { data, error } = await this.supabase
+      .from("class_bookings")
+      .select("*")
+      .eq("class_id", classId)
+      .order("booked_at", { ascending: true })
+      .limit(limit);
+
+    throwIfError(error, "GUILD_STAFF_BOOKINGS_FAILED", "Unable to load class bookings.");
+
+    return ((data as ClassBookingRow[]) ?? []).map(mapBooking);
+  }
+
+  async listClassWaitlist(gymId: string, classId: string, limit = 300): Promise<ClassWaitlistEntry[]> {
+    const { data: gymClass, error: classError } = await this.supabase
+      .from("gym_classes")
+      .select("id,gym_id")
+      .eq("id", classId)
+      .maybeSingle();
+
+    throwIfError(classError, "GUILD_STAFF_CLASS_LOOKUP_FAILED", "Unable to resolve class.");
+
+    if (!gymClass || (gymClass as { gym_id: string }).gym_id !== gymId) {
+      throw new KruxtAppError("GUILD_STAFF_CLASS_NOT_FOUND", "Class not found for this gym.");
+    }
+
+    const { data, error } = await this.supabase
+      .from("class_waitlist")
+      .select("*")
+      .eq("class_id", classId)
+      .order("position", { ascending: true })
+      .limit(limit);
+
+    throwIfError(error, "GUILD_STAFF_WAITLIST_FAILED", "Unable to load class waitlist.");
+
+    return ((data as ClassWaitlistRow[]) ?? []).map(mapWaitlist);
+  }
+
+  async listRecentAccessLogs(gymId: string, limit = 150): Promise<AccessLog[]> {
+    const { data, error } = await this.supabase
+      .from("access_logs")
+      .select("*")
+      .eq("gym_id", gymId)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    throwIfError(error, "GUILD_STAFF_ACCESS_LOGS_FAILED", "Unable to load access logs.");
+
+    return ((data as AccessLogRow[]) ?? []).map(mapAccessLog);
+  }
+
+  async countPendingMembershipApprovals(gymId: string): Promise<number> {
+    const { count, error } = await this.supabase
+      .from("gym_memberships")
+      .select("id", { count: "exact", head: true })
+      .eq("gym_id", gymId)
+      .eq("membership_status", "pending");
+
+    throwIfError(error, "GUILD_STAFF_PENDING_APPROVALS_FAILED", "Unable to load pending approvals.");
+
+    return count ?? 0;
+  }
+
+  async getComplianceTaskCounts(gymId: string): Promise<GymComplianceTaskCounts> {
+    const [activeWaivers, activeContracts] = await Promise.all([
+      this.listActiveWaivers(gymId),
+      this.listActiveContracts(gymId)
+    ]);
+
+    const { data: activeMemberships, error: membershipsError } = await this.supabase
+      .from("gym_memberships")
+      .select("user_id,membership_status")
+      .eq("gym_id", gymId)
+      .in("membership_status", ["active", "trial"]);
+
+    throwIfError(
+      membershipsError,
+      "GUILD_STAFF_COMPLIANCE_MEMBERSHIPS_FAILED",
+      "Unable to load active members for compliance checks."
+    );
+
+    const activeMemberIds = Array.from(
+      new Set(
+        ((activeMemberships as Array<{ user_id: string }>) ?? [])
+          .map((row) => row.user_id)
+          .filter((value): value is string => Boolean(value))
+      )
+    );
+
+    const waiverIds = activeWaivers.map((waiver) => waiver.id);
+    const contractIds = activeContracts.map((contract) => contract.id);
+
+    const [waiverAcceptances, contractAcceptances] = await Promise.all([
+      waiverIds.length > 0 && activeMemberIds.length > 0
+        ? this.supabase
+            .from("waiver_acceptances")
+            .select("waiver_id,user_id")
+            .in("waiver_id", waiverIds)
+            .in("user_id", activeMemberIds)
+        : Promise.resolve({ data: [], error: null }),
+      contractIds.length > 0 && activeMemberIds.length > 0
+        ? this.supabase
+            .from("contract_acceptances")
+            .select("contract_id,user_id")
+            .in("contract_id", contractIds)
+            .in("user_id", activeMemberIds)
+        : Promise.resolve({ data: [], error: null })
+    ]);
+
+    throwIfError(
+      waiverAcceptances.error,
+      "GUILD_STAFF_WAIVER_ACCEPTANCES_FAILED",
+      "Unable to load waiver acceptance coverage."
+    );
+    throwIfError(
+      contractAcceptances.error,
+      "GUILD_STAFF_CONTRACT_ACCEPTANCES_FAILED",
+      "Unable to load contract acceptance coverage."
+    );
+
+    const waiverAcceptanceKeys = new Set(
+      (((waiverAcceptances.data as Array<{ waiver_id: string; user_id: string }>) ?? []).map(
+        (row) => `${row.user_id}:${row.waiver_id}`
+      ))
+    );
+    const contractAcceptanceKeys = new Set(
+      (((contractAcceptances.data as Array<{ contract_id: string; user_id: string }>) ?? []).map(
+        (row) => `${row.user_id}:${row.contract_id}`
+      ))
+    );
+
+    let unresolvedWaiverTasks = 0;
+    for (const userId of activeMemberIds) {
+      for (const waiverId of waiverIds) {
+        if (!waiverAcceptanceKeys.has(`${userId}:${waiverId}`)) {
+          unresolvedWaiverTasks += 1;
+        }
+      }
+    }
+
+    let unresolvedContractTasks = 0;
+    for (const userId of activeMemberIds) {
+      for (const contractId of contractIds) {
+        if (!contractAcceptanceKeys.has(`${userId}:${contractId}`)) {
+          unresolvedContractTasks += 1;
+        }
+      }
+    }
+
+    return {
+      activeMembers: activeMemberIds.length,
+      activeWaivers: waiverIds.length,
+      activeContracts: contractIds.length,
+      unresolvedWaiverTasks,
+      unresolvedContractTasks
+    };
+  }
+
+  async assertStaffAccess(gymId: string, userId: string): Promise<GymMembership> {
+    const membership = await this.getMembershipForGymUser(gymId, userId);
+    if (!membership) {
+      throw new KruxtAppError("GUILD_MEMBERSHIP_REQUIRED", "Gym membership is required.");
+    }
+
+    if (!isStaffRole(membership.role)) {
+      throw new KruxtAppError("GUILD_STAFF_REQUIRED", "Staff role is required for this action.");
+    }
+
+    if (!isActiveMembership(membership.membershipStatus)) {
+      throw new KruxtAppError("GUILD_STAFF_INACTIVE", "Staff membership must be active.");
+    }
+
+    return membership;
+  }
+
+  async loadStaffOpsSnapshot(
+    gymId: string,
+    staffUserId: string,
+    preferredClassId?: string
+  ): Promise<GymStaffOpsSnapshot> {
+    await this.assertStaffAccess(gymId, staffUserId);
+
+    const classes = await this.listTodayClasses(gymId);
+    const selectedClassId =
+      preferredClassId && classes.some((gymClass) => gymClass.id === preferredClassId)
+        ? preferredClassId
+        : classes[0]?.id;
+
+    const [selectedClassBookings, selectedClassWaitlist, recentCheckins, recentAccessLogs, pendingApprovals, complianceTasks] =
+      await Promise.all([
+        selectedClassId ? this.listClassBookings(gymId, selectedClassId) : Promise.resolve([]),
+        selectedClassId ? this.listClassWaitlist(gymId, selectedClassId) : Promise.resolve([]),
+        this.listRecentCheckins(gymId, 150),
+        this.listRecentAccessLogs(gymId, 150),
+        this.countPendingMembershipApprovals(gymId),
+        this.getComplianceTaskCounts(gymId)
+      ]);
+
+    return {
+      classes,
+      selectedClassId,
+      selectedClassBookings,
+      selectedClassWaitlist,
+      recentCheckins,
+      recentAccessLogs,
+      pendingApprovals,
+      complianceTasks
+    };
   }
 }

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -13,6 +13,7 @@
 - Phase 4 mobile UI wiring: Proof Feed controller with interaction + moderation refresh loops
 - Phase 5 runtime: admin B2B ops service layer for classes, waitlist, waivers, contracts, check-ins, and billing telemetry
 - Phase 5 admin UI wiring: Ops Console controller with class/waitlist/check-in/acceptance mutation refresh loops
+- Phase 5 mobile UI wiring: Guild Hall split-view controller with member/staff contracts and confirm-gated staff controls
 - Phase 6 runtime: Apple/Garmin integration pipeline (mobile integration service + webhook ingest + sync dispatcher + cursor persistence)
 - Phase 6 mobile UI wiring: connector controller with provider activation, sync queueing, and mapping/idempotency validation
 - Phase 6 monitoring runtime: admin integration health + sync failure monitor flow for gym staff

--- a/docs/phase5-runtime.md
+++ b/docs/phase5-runtime.md
@@ -8,12 +8,23 @@ Phase 5 runtime now includes an admin service layer for B2B daily operations:
 - Check-in and access log recording/monitoring
 - Billing telemetry (subscriptions, invoices, payments, refunds, dunning events)
 
+It now also includes a mobile Guild Hall split-view UI contract for Prompt 4:
+
+- Member view data: membership summary, upcoming classes, waitlist state, recent check-ins, waiver/contract status
+- Staff view data: operations board, class pressure, unresolved compliance tasks, check-in anomalies
+- Guardrails: member surface hides staff controls; staff controls are confirmation-gated
+
 ## Admin entrypoints
 
 - `apps/admin/src/services/b2b-ops-service.ts`
 - `apps/admin/src/flows/phase5-b2b-ops.ts`
 - `apps/admin/src/flows/phase5-ops-console-ui.ts`
 - `apps/admin/src/app/page.ts`
+
+## Mobile entrypoints
+
+- `apps/mobile/src/flows/phase5-guild-hall-ui.ts`
+- `apps/mobile/src/services/gym-service.ts`
 
 Core methods:
 


### PR DESCRIPTION
## Summary
- add createPhase5GuildHallUiFlow for Prompt 4 role-aware Guild Hall loading
- extend mobile GymService with read-only member/staff Phase 5 contracts (classes, waitlist, check-ins, compliance, ops snapshot)
- wire mobile app scaffold and exports for Phase 5 flow
- update runtime docs/status to include Phase 5 mobile contract surface

## Validation
- npx tsc -p apps/mobile/tsconfig.json --noEmit
- pnpm typecheck (fails locally: pnpm not installed in this environment)

## Notes
- staff controls are confirmation-gated via getStaffConfirmDialog
- member surface never exposes staff mutation actions