### PR TITLE
feat(phase5): add admin Members Console UI flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Operational features are controlled by flags in `public.feature_flags`.
 
 - B2B admin ops service: `apps/admin/src/services/b2b-ops-service.ts`
 - B2B ops flow snapshot: `apps/admin/src/flows/phase5-b2b-ops.ts`
+- Members console UI controller: `apps/admin/src/flows/phase5-members-console-ui.ts`
 - Ops console UI controller: `apps/admin/src/flows/phase5-ops-console-ui.ts`
 - Staff acceptance RPC migration set starts at: `packages/db/supabase/migrations/202602190364_krux_beta_part3_s023.sql`
 - Usage notes: `docs/phase5-runtime.md`
+- Members console wiring guide: `docs/phase5-members-console-ui-wiring.md`
 - Screen wiring guide: `docs/phase5-ops-console-ui-wiring.md`
 
 ## Phase 6 Runtime

--- a/apps/admin/src/app/page.ts
+++ b/apps/admin/src/app/page.ts
@@ -1,6 +1,7 @@
 import { phase2StaffConsoleUiChecklist } from "../flows/phase2-staff-console-ui";
 import { phase6IntegrationMonitorChecklist } from "../flows/phase6-integration-monitor";
 import { phase5OpsConsoleUiChecklist } from "../flows/phase5-ops-console-ui";
+import { phase5MembersConsoleUiChecklist } from "../flows/phase5-members-console-ui";
 import { phase8ComplianceOpsChecklist } from "../flows/phase8-compliance-ops";
 import { phase10CustomizationSupportChecklist } from "../flows/phase10-customization-support";
 import { phase10PlatformControlPlaneChecklist } from "../flows/phase10-platform-control-plane";
@@ -33,7 +34,7 @@ export function adminHomePageScaffold() {
       ]
     },
     phase5: {
-      modules: [...phase5OpsConsoleUiChecklist],
+      modules: [...phase5MembersConsoleUiChecklist, ...phase5OpsConsoleUiChecklist],
       screenFlow:
         "class schedule -> bookings/waitlist -> check-in/access -> waiver/contract evidence -> refreshed snapshot",
       recoverableErrors: [
@@ -58,7 +59,13 @@ export function adminHomePageScaffold() {
         "B2BOpsService.listInvoices",
         "B2BOpsService.listPaymentTransactions",
         "B2BOpsService.listRefunds",
-        "B2BOpsService.listDunningEvents"
+        "B2BOpsService.listDunningEvents",
+        "createPhase5MembersConsoleUiFlow.load",
+        "createPhase5MembersConsoleUiFlow.assignRole",
+        "createPhase5MembersConsoleUiFlow.setStatus",
+        "createPhase5MembersConsoleUiFlow.bulkAssignRole",
+        "createPhase5MembersConsoleUiFlow.bulkSetStatus",
+        "GymAdminService.listGymMemberProfiles"
       ]
     },
     phase6: {

--- a/apps/admin/src/flows/phase5-members-console-ui.ts
+++ b/apps/admin/src/flows/phase5-members-console-ui.ts
@@ -1,0 +1,710 @@
+import type {
+  GymMembership,
+  GymRole,
+  MembershipStatus,
+  MemberSubscription
+} from "@kruxt/types";
+
+import {
+  B2BOpsService,
+  createAdminSupabaseClient,
+  GymAdminService,
+  KruxtAdminError,
+  type AdminMemberProfile
+} from "../services";
+import {
+  createPhase2StaffConsoleUiFlow,
+  phase2StaffConsoleUiChecklist,
+  type StaffConsoleMutationResult
+} from "./phase2-staff-console-ui";
+
+export type MembersConsoleUiStep =
+  | "search_filter"
+  | "role_assignment"
+  | "status_actions"
+  | "bulk_actions"
+  | "profile_panel"
+  | "snapshot_refresh";
+
+export type MembersConsoleStatusAction = MembershipStatus | "past_due";
+export type MembersConsoleSegment =
+  | "all"
+  | "pending"
+  | "trial"
+  | "active"
+  | "past_due"
+  | "paused"
+  | "cancelled";
+
+export type MembersConsoleColumnKey =
+  | "member"
+  | "role"
+  | "membership_status"
+  | "subscription_status"
+  | "plan"
+  | "last_checkin"
+  | "privacy"
+  | "joined_at";
+
+export type MembersConsoleColumnPreset = "default" | "operations" | "billing" | "compliance";
+
+export interface MembersConsoleLoadOptions {
+  search?: string;
+  segment?: MembersConsoleSegment;
+  roles?: GymRole[];
+  columnPreset?: MembersConsoleColumnPreset;
+  selectedUserId?: string;
+}
+
+export interface MembersConsoleMemberRow {
+  membershipId: string;
+  userId: string;
+  username: string;
+  displayName: string;
+  avatarUrl?: string | null;
+  role: GymRole;
+  membershipStatus: MembershipStatus;
+  subscriptionStatus: MemberSubscription["status"] | null;
+  effectiveStatus: Exclude<MembersConsoleSegment, "all">;
+  membershipPlanId?: string | null;
+  joinedAt?: string | null;
+  lastCheckinAt?: string | null;
+  openPrivacyRequests: number;
+  isPending: boolean;
+  canAssignRole: boolean;
+}
+
+export interface MembersConsoleTimelineEvent {
+  id: string;
+  kind: "membership" | "checkin" | "subscription" | "privacy_request";
+  occurredAt: string;
+  title: string;
+  detail: string;
+  tone: "neutral" | "positive" | "warning" | "critical";
+}
+
+export interface MembersConsoleProfilePanel {
+  userId: string;
+  profile: AdminMemberProfile | null;
+  membership: MembersConsoleMemberRow;
+  timeline: MembersConsoleTimelineEvent[];
+}
+
+export interface MembersConsoleQueueSummary {
+  pendingMembershipCount: number;
+  pendingWaitlistCount: number;
+  openPrivacyRequestCount: number;
+  upcomingClassCount: number;
+}
+
+export interface MembersConsoleSnapshot {
+  gymId: string;
+  query: Required<Pick<MembersConsoleLoadOptions, "search" | "segment" | "roles" | "columnPreset">>;
+  queueSummary: MembersConsoleQueueSummary;
+  rows: MembersConsoleMemberRow[];
+  filteredRows: MembersConsoleMemberRow[];
+  segmentCounts: Record<MembersConsoleSegment, number>;
+  columnPresets: Record<MembersConsoleColumnPreset, MembersConsoleColumnKey[]>;
+  visibleColumns: MembersConsoleColumnKey[];
+  selectedProfilePanel: MembersConsoleProfilePanel | null;
+  statusActions: MembersConsoleStatusAction[];
+  roleActions: GymRole[];
+  tableUx: {
+    stickyHeader: true;
+    supportsBulkActions: true;
+    requiresAuditNoteForRoleChange: true;
+  };
+}
+
+export interface MembersConsoleUiError {
+  code: string;
+  step: MembersConsoleUiStep;
+  message: string;
+  recoverable: boolean;
+}
+
+export interface MembersConsoleLoadSuccess {
+  ok: true;
+  snapshot: MembersConsoleSnapshot;
+}
+
+export interface MembersConsoleLoadFailure {
+  ok: false;
+  error: MembersConsoleUiError;
+}
+
+export type MembersConsoleLoadResult = MembersConsoleLoadSuccess | MembersConsoleLoadFailure;
+
+export interface MembersConsoleMutationSuccess {
+  ok: true;
+  action: "assign_role" | "set_status" | "bulk_assign_role" | "bulk_set_status";
+  updatedMembershipIds: string[];
+  failedMembershipIds: string[];
+  snapshot: MembersConsoleSnapshot;
+}
+
+export interface MembersConsoleMutationFailure {
+  ok: false;
+  error: MembersConsoleUiError;
+}
+
+export type MembersConsoleMutationResult = MembersConsoleMutationSuccess | MembersConsoleMutationFailure;
+
+const COLUMN_PRESETS: Record<MembersConsoleColumnPreset, MembersConsoleColumnKey[]> = {
+  default: ["member", "role", "membership_status", "subscription_status", "plan", "last_checkin", "joined_at"],
+  operations: ["member", "role", "membership_status", "last_checkin", "privacy", "joined_at"],
+  billing: ["member", "membership_status", "subscription_status", "plan", "privacy", "joined_at"],
+  compliance: ["member", "role", "membership_status", "privacy", "last_checkin", "joined_at"]
+};
+
+const MEMBERSHIP_STATUS_ACTIONS: MembersConsoleStatusAction[] = [
+  "trial",
+  "active",
+  "past_due",
+  "paused",
+  "cancelled"
+];
+
+const ROLE_ACTIONS: GymRole[] = ["leader", "officer", "coach", "member"];
+
+export const phase5MembersConsoleUiChecklist = [
+  ...phase2StaffConsoleUiChecklist,
+  "Load searchable/segmented member rows for desktop operations",
+  "Support bulk status and role actions for staff operators",
+  "Require audit notes for every role-change action",
+  "Render profile side panel with timeline context"
+] as const;
+
+function normalizeSearch(search: string): string {
+  return search.trim().toLowerCase();
+}
+
+function includesSearch(row: MembersConsoleMemberRow, search: string): boolean {
+  if (!search) {
+    return true;
+  }
+
+  const haystack = `${row.displayName} ${row.username} ${row.userId}`.toLowerCase();
+  return haystack.includes(search);
+}
+
+function resolveEffectiveStatus(
+  membershipStatus: MembershipStatus,
+  subscriptionStatus: MemberSubscription["status"] | null
+): Exclude<MembersConsoleSegment, "all"> {
+  if (subscriptionStatus === "past_due" || subscriptionStatus === "unpaid") {
+    return "past_due";
+  }
+
+  if (membershipStatus === "pending") {
+    return "pending";
+  }
+  if (membershipStatus === "trial") {
+    return "trial";
+  }
+  if (membershipStatus === "active") {
+    return "active";
+  }
+  if (membershipStatus === "paused") {
+    return "paused";
+  }
+  return "cancelled";
+}
+
+function buildSegmentCounts(rows: MembersConsoleMemberRow[]): Record<MembersConsoleSegment, number> {
+  const counts: Record<MembersConsoleSegment, number> = {
+    all: rows.length,
+    pending: 0,
+    trial: 0,
+    active: 0,
+    past_due: 0,
+    paused: 0,
+    cancelled: 0
+  };
+
+  for (const row of rows) {
+    counts[row.effectiveStatus] += 1;
+  }
+
+  return counts;
+}
+
+function applyFilters(rows: MembersConsoleMemberRow[], options: MembersConsoleLoadOptions): MembersConsoleMemberRow[] {
+  const search = normalizeSearch(options.search ?? "");
+  const selectedRoles = options.roles ?? [];
+  const segment = options.segment ?? "all";
+
+  return rows
+    .filter((row) => includesSearch(row, search))
+    .filter((row) => (segment === "all" ? true : row.effectiveStatus === segment))
+    .filter((row) => (selectedRoles.length > 0 ? selectedRoles.includes(row.role) : true));
+}
+
+function mapErrorStep(code: string): MembersConsoleUiStep {
+  if (code.includes("AUDIT_NOTE")) {
+    return "role_assignment";
+  }
+  if (code.includes("BULK")) {
+    return "bulk_actions";
+  }
+  if (code.includes("STATUS") || code.includes("SUBSCRIPTION")) {
+    return "status_actions";
+  }
+  if (code.includes("PROFILE") || code.includes("TIMELINE")) {
+    return "profile_panel";
+  }
+  if (code.includes("MEMBERSHIP") || code.includes("ROLE_ASSIGN")) {
+    return "search_filter";
+  }
+  return "snapshot_refresh";
+}
+
+function mapErrorMessage(code: string, fallback: string): string {
+  if (code === "MEMBERS_CONSOLE_AUDIT_NOTE_REQUIRED") {
+    return "Role changes require an audit note.";
+  }
+  if (code === "MEMBERS_CONSOLE_MEMBERSHIP_NOT_FOUND") {
+    return "Membership record not found. Refresh and retry.";
+  }
+  if (code === "ADMIN_STAFF_ACCESS_DENIED") {
+    return "Staff access is required to use members console actions.";
+  }
+  return fallback;
+}
+
+function mapUiError(error: unknown): MembersConsoleUiError {
+  const appError =
+    error instanceof KruxtAdminError
+      ? error
+      : new KruxtAdminError("ADMIN_MEMBERS_CONSOLE_ACTION_FAILED", "Unable to complete members action.", error);
+
+  return {
+    code: appError.code,
+    step: mapErrorStep(appError.code),
+    message: mapErrorMessage(appError.code, appError.message),
+    recoverable: !["ADMIN_AUTH_REQUIRED", "ADMIN_STAFF_ACCESS_DENIED"].includes(appError.code)
+  };
+}
+
+function assertRoleAuditNote(note: string): void {
+  if (note.trim().length < 5) {
+    throw new KruxtAdminError("MEMBERS_CONSOLE_AUDIT_NOTE_REQUIRED", "Role change audit note is required.");
+  }
+}
+
+function throwIfPhase2MutationFailed(result: StaffConsoleMutationResult): void {
+  if (!result.ok) {
+    throw new KruxtAdminError(result.error.code, result.error.message);
+  }
+}
+
+function buildTimeline(
+  membershipRow: MembersConsoleMemberRow,
+  membership: GymMembership,
+  profile: AdminMemberProfile | null,
+  subscription: MemberSubscription | null,
+  checkins: Array<{ checkedInAt: string; result: string; sourceChannel: string }>,
+  privacyRequestCount: number
+): MembersConsoleTimelineEvent[] {
+  const events: MembersConsoleTimelineEvent[] = [];
+
+  events.push({
+    id: `membership:${membership.id}`,
+    kind: "membership",
+    occurredAt: membership.startedAt ?? profile?.createdAt ?? new Date(0).toISOString(),
+    title: "Membership state",
+    detail: `Role ${membership.role}, status ${membership.membershipStatus}.`,
+    tone: membership.membershipStatus === "active" || membership.membershipStatus === "trial" ? "positive" : "warning"
+  });
+
+  if (subscription) {
+    events.push({
+      id: `subscription:${subscription.id}`,
+      kind: "subscription",
+      occurredAt: subscription.updatedAt,
+      title: "Billing state",
+      detail: `Subscription status ${subscription.status}.`,
+      tone:
+        subscription.status === "active" || subscription.status === "trialing"
+          ? "positive"
+          : subscription.status === "past_due" || subscription.status === "unpaid"
+            ? "critical"
+            : "warning"
+    });
+  }
+
+  for (const checkin of checkins.slice(0, 10)) {
+    events.push({
+      id: `checkin:${membership.id}:${checkin.checkedInAt}`,
+      kind: "checkin",
+      occurredAt: checkin.checkedInAt,
+      title: "Gym access event",
+      detail: `Result ${checkin.result} via ${checkin.sourceChannel}.`,
+      tone: checkin.result === "allowed" ? "positive" : "warning"
+    });
+  }
+
+  if (privacyRequestCount > 0) {
+    events.push({
+      id: `privacy:${membership.id}`,
+      kind: "privacy_request",
+      occurredAt: new Date().toISOString(),
+      title: "Open privacy requests",
+      detail: `${privacyRequestCount} request(s) currently open.`,
+      tone: "warning"
+    });
+  }
+
+  return events.sort((left, right) => right.occurredAt.localeCompare(left.occurredAt));
+}
+
+function buildNormalizedOptions(options: MembersConsoleLoadOptions): Required<Pick<MembersConsoleLoadOptions, "search" | "segment" | "roles" | "columnPreset">> {
+  return {
+    search: options.search ?? "",
+    segment: options.segment ?? "all",
+    roles: options.roles ?? [],
+    columnPreset: options.columnPreset ?? "default"
+  };
+}
+
+export function createPhase5MembersConsoleUiFlow() {
+  const supabase = createAdminSupabaseClient();
+  const admin = new GymAdminService(supabase);
+  const b2b = new B2BOpsService(supabase);
+  const phase2 = createPhase2StaffConsoleUiFlow();
+
+  const loadSnapshot = async (
+    gymId: string,
+    options: MembersConsoleLoadOptions = {}
+  ): Promise<MembersConsoleSnapshot> => {
+    const queueResult = await phase2.load(gymId);
+    if (!queueResult.ok) {
+      throw new KruxtAdminError(queueResult.error.code, queueResult.error.message);
+    }
+
+    const memberships = queueResult.snapshot.memberships;
+    const userIds = Array.from(new Set(memberships.map((membership) => membership.userId)));
+
+    const [profiles, subscriptions, recentCheckins] = await Promise.all([
+      admin.listGymMemberProfiles(gymId, userIds),
+      b2b.listMemberSubscriptions(gymId, 500),
+      b2b.listRecentCheckins(gymId, 800)
+    ]);
+
+    const profileByUserId = new Map<string, AdminMemberProfile>();
+    for (const profile of profiles) {
+      profileByUserId.set(profile.id, profile);
+    }
+
+    const subscriptionByUserId = new Map<string, MemberSubscription>();
+    for (const subscription of subscriptions) {
+      if (!subscriptionByUserId.has(subscription.userId)) {
+        subscriptionByUserId.set(subscription.userId, subscription);
+      }
+    }
+
+    const lastCheckinByUserId = new Map<string, { checkedInAt: string; result: string; sourceChannel: string }>();
+    for (const checkin of recentCheckins) {
+      if (!lastCheckinByUserId.has(checkin.userId)) {
+        lastCheckinByUserId.set(checkin.userId, {
+          checkedInAt: checkin.checkedInAt,
+          result: checkin.result,
+          sourceChannel: checkin.sourceChannel
+        });
+      }
+    }
+
+    const openPrivacyCountByUserId = new Map<string, number>();
+    for (const request of queueResult.snapshot.openPrivacyRequests) {
+      openPrivacyCountByUserId.set(request.userId, (openPrivacyCountByUserId.get(request.userId) ?? 0) + 1);
+    }
+
+    const rows: MembersConsoleMemberRow[] = memberships.map((membership) => {
+      const profile = profileByUserId.get(membership.userId);
+      const subscription = subscriptionByUserId.get(membership.userId) ?? null;
+      const lastCheckin = lastCheckinByUserId.get(membership.userId);
+      const effectiveStatus = resolveEffectiveStatus(membership.membershipStatus, subscription?.status ?? null);
+
+      return {
+        membershipId: membership.id,
+        userId: membership.userId,
+        username: profile?.username ?? membership.userId.slice(0, 8),
+        displayName: profile?.displayName ?? profile?.username ?? membership.userId.slice(0, 8),
+        avatarUrl: profile?.avatarUrl,
+        role: membership.role,
+        membershipStatus: membership.membershipStatus,
+        subscriptionStatus: subscription?.status ?? null,
+        effectiveStatus,
+        membershipPlanId: membership.membershipPlanId,
+        joinedAt: membership.startedAt,
+        lastCheckinAt: lastCheckin?.checkedInAt,
+        openPrivacyRequests: openPrivacyCountByUserId.get(membership.userId) ?? 0,
+        isPending: membership.membershipStatus === "pending",
+        canAssignRole: membership.membershipStatus === "active" || membership.membershipStatus === "trial"
+      };
+    });
+
+    const normalizedOptions = buildNormalizedOptions(options);
+    const filteredRows = applyFilters(rows, options);
+    const segmentCounts = buildSegmentCounts(rows);
+    const selectedUserId = options.selectedUserId ?? filteredRows[0]?.userId ?? rows[0]?.userId;
+
+    let selectedProfilePanel: MembersConsoleProfilePanel | null = null;
+    if (selectedUserId) {
+      const selectedRow = rows.find((row) => row.userId === selectedUserId);
+      const selectedMembership = memberships.find((membership) => membership.userId === selectedUserId);
+
+      if (selectedRow && selectedMembership) {
+        const selectedProfile = profileByUserId.get(selectedUserId) ?? null;
+        const selectedSubscription = subscriptionByUserId.get(selectedUserId) ?? null;
+        const selectedCheckins = recentCheckins
+          .filter((checkin) => checkin.userId === selectedUserId)
+          .map((checkin) => ({
+            checkedInAt: checkin.checkedInAt,
+            result: checkin.result,
+            sourceChannel: checkin.sourceChannel
+          }));
+
+        selectedProfilePanel = {
+          userId: selectedUserId,
+          profile: selectedProfile,
+          membership: selectedRow,
+          timeline: buildTimeline(
+            selectedRow,
+            selectedMembership,
+            selectedProfile,
+            selectedSubscription,
+            selectedCheckins,
+            selectedRow.openPrivacyRequests
+          )
+        };
+      }
+    }
+
+    return {
+      gymId,
+      query: normalizedOptions,
+      queueSummary: {
+        pendingMembershipCount: queueResult.snapshot.pendingMemberships.length,
+        pendingWaitlistCount: queueResult.snapshot.pendingWaitlist.length,
+        openPrivacyRequestCount: queueResult.snapshot.openPrivacyRequests.length,
+        upcomingClassCount: queueResult.snapshot.upcomingClasses.length
+      },
+      rows,
+      filteredRows,
+      segmentCounts,
+      columnPresets: COLUMN_PRESETS,
+      visibleColumns: COLUMN_PRESETS[normalizedOptions.columnPreset],
+      selectedProfilePanel,
+      statusActions: MEMBERSHIP_STATUS_ACTIONS,
+      roleActions: ROLE_ACTIONS,
+      tableUx: {
+        stickyHeader: true,
+        supportsBulkActions: true,
+        requiresAuditNoteForRoleChange: true
+      }
+    };
+  };
+
+  const markPastDue = async (gymId: string, membershipId: string): Promise<void> => {
+    const memberships = await admin.listGymMemberships(gymId);
+    const target = memberships.find((membership) => membership.id === membershipId);
+    if (!target) {
+      throw new KruxtAdminError("MEMBERS_CONSOLE_MEMBERSHIP_NOT_FOUND", "Membership not found.");
+    }
+
+    const subscriptions = await b2b.listMemberSubscriptions(gymId, 500);
+    const existing =
+      subscriptions.find((subscription) => subscription.userId === target.userId && subscription.membershipPlanId === target.membershipPlanId) ??
+      subscriptions.find((subscription) => subscription.userId === target.userId);
+
+    await b2b.upsertMemberSubscription(
+      gymId,
+      {
+        userId: target.userId,
+        membershipPlanId: target.membershipPlanId ?? existing?.membershipPlanId ?? undefined,
+        status: "past_due",
+        provider: existing?.provider ?? "stripe",
+        providerCustomerId: existing?.providerCustomerId ?? undefined,
+        providerSubscriptionId: existing?.providerSubscriptionId ?? undefined,
+        currentPeriodStart: existing?.currentPeriodStart ?? undefined,
+        currentPeriodEnd: existing?.currentPeriodEnd ?? undefined,
+        trialEndsAt: existing?.trialEndsAt ?? undefined,
+        cancelAt: existing?.cancelAt ?? undefined,
+        canceledAt: existing?.canceledAt ?? undefined,
+        paymentMethodLast4: existing?.paymentMethodLast4 ?? undefined,
+        paymentMethodBrand: existing?.paymentMethodBrand ?? undefined,
+        metadata: {
+          ...(existing?.metadata ?? {}),
+          marked_past_due_by_ui: true
+        }
+      },
+      existing?.id
+    );
+  };
+
+  const runSingleMutation = async (
+    gymId: string,
+    action: MembersConsoleMutationSuccess["action"],
+    membershipId: string,
+    mutate: () => Promise<void>,
+    options: MembersConsoleLoadOptions = {}
+  ): Promise<MembersConsoleMutationResult> => {
+    try {
+      await mutate();
+      const snapshot = await loadSnapshot(gymId, options);
+      return {
+        ok: true,
+        action,
+        updatedMembershipIds: [membershipId],
+        failedMembershipIds: [],
+        snapshot
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: mapUiError(error)
+      };
+    }
+  };
+
+  const runBulkMutation = async (
+    gymId: string,
+    action: MembersConsoleMutationSuccess["action"],
+    membershipIds: string[],
+    mutate: (membershipId: string) => Promise<void>,
+    options: MembersConsoleLoadOptions = {}
+  ): Promise<MembersConsoleMutationResult> => {
+    const uniqueMembershipIds = Array.from(new Set(membershipIds));
+    const failedMembershipIds: string[] = [];
+    const updatedMembershipIds: string[] = [];
+
+    for (const membershipId of uniqueMembershipIds) {
+      try {
+        await mutate(membershipId);
+        updatedMembershipIds.push(membershipId);
+      } catch {
+        failedMembershipIds.push(membershipId);
+      }
+    }
+
+    if (updatedMembershipIds.length === 0 && failedMembershipIds.length > 0) {
+      return {
+        ok: false,
+        error: mapUiError(new KruxtAdminError("MEMBERS_CONSOLE_BULK_ACTION_FAILED", "No selected rows were updated."))
+      };
+    }
+
+    try {
+      const snapshot = await loadSnapshot(gymId, options);
+      return {
+        ok: true,
+        action,
+        updatedMembershipIds,
+        failedMembershipIds,
+        snapshot
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: mapUiError(error)
+      };
+    }
+  };
+
+  return {
+    checklist: [...phase5MembersConsoleUiChecklist],
+    statusActions: [...MEMBERSHIP_STATUS_ACTIONS],
+    roleActions: [...ROLE_ACTIONS],
+    columnPresets: { ...COLUMN_PRESETS },
+    load: async (gymId: string, options: MembersConsoleLoadOptions = {}): Promise<MembersConsoleLoadResult> => {
+      try {
+        return {
+          ok: true,
+          snapshot: await loadSnapshot(gymId, options)
+        };
+      } catch (error) {
+        return {
+          ok: false,
+          error: mapUiError(error)
+        };
+      }
+    },
+    assignRole: async (
+      gymId: string,
+      membershipId: string,
+      role: GymRole,
+      auditNote: string,
+      options: MembersConsoleLoadOptions = {}
+    ): Promise<MembersConsoleMutationResult> =>
+      runSingleMutation(
+        gymId,
+        "assign_role",
+        membershipId,
+        async () => {
+          assertRoleAuditNote(auditNote);
+          const mutation = await phase2.assignMembershipRole(gymId, membershipId, role);
+          throwIfPhase2MutationFailed(mutation);
+        },
+        options
+      ),
+    setStatus: async (
+      gymId: string,
+      membershipId: string,
+      status: MembersConsoleStatusAction,
+      options: MembersConsoleLoadOptions = {}
+    ): Promise<MembersConsoleMutationResult> =>
+      runSingleMutation(
+        gymId,
+        "set_status",
+        membershipId,
+        async () => {
+          if (status === "past_due") {
+            await markPastDue(gymId, membershipId);
+            return;
+          }
+
+          const mutation = await phase2.setMembershipStatus(gymId, membershipId, status);
+          throwIfPhase2MutationFailed(mutation);
+        },
+        options
+      ),
+    bulkAssignRole: async (
+      gymId: string,
+      membershipIds: string[],
+      role: GymRole,
+      auditNote: string,
+      options: MembersConsoleLoadOptions = {}
+    ): Promise<MembersConsoleMutationResult> =>
+      runBulkMutation(
+        gymId,
+        "bulk_assign_role",
+        membershipIds,
+        async (membershipId) => {
+          assertRoleAuditNote(auditNote);
+          await admin.assignMembershipRole(gymId, membershipId, role);
+        },
+        options
+      ),
+    bulkSetStatus: async (
+      gymId: string,
+      membershipIds: string[],
+      status: MembersConsoleStatusAction,
+      options: MembersConsoleLoadOptions = {}
+    ): Promise<MembersConsoleMutationResult> =>
+      runBulkMutation(
+        gymId,
+        "bulk_set_status",
+        membershipIds,
+        async (membershipId) => {
+          if (status === "past_due") {
+            await markPastDue(gymId, membershipId);
+            return;
+          }
+
+          await admin.updateMembershipStatus(gymId, membershipId, status);
+        },
+        options
+      )
+  };
+}

--- a/apps/admin/src/index.ts
+++ b/apps/admin/src/index.ts
@@ -3,6 +3,7 @@ export * from "./services";
 export * from "./flows/phase2-staff-ops";
 export * from "./flows/phase2-staff-console-ui";
 export * from "./flows/phase5-b2b-ops";
+export * from "./flows/phase5-members-console-ui";
 export * from "./flows/phase5-ops-console-ui";
 export * from "./flows/phase6-integration-monitor";
 export * from "./flows/phase8-compliance-ops";

--- a/docs/phase-status.md
+++ b/docs/phase-status.md
@@ -12,6 +12,7 @@
 - Phase 4 runtime: social graph/feed ranking/notification service layer for mobile
 - Phase 4 mobile UI wiring: Proof Feed controller with interaction + moderation refresh loops
 - Phase 5 runtime: admin B2B ops service layer for classes, waitlist, waivers, contracts, check-ins, and billing telemetry
+- Phase 5 admin UI wiring: Members Console controller with search/filter, bulk actions, role audit-note gating, and profile timeline side panel
 - Phase 5 admin UI wiring: Ops Console controller with class/waitlist/check-in/acceptance mutation refresh loops
 - Phase 6 runtime: Apple/Garmin integration pipeline (mobile integration service + webhook ingest + sync dispatcher + cursor persistence)
 - Phase 6 mobile UI wiring: connector controller with provider activation, sync queueing, and mapping/idempotency validation

--- a/docs/phase5-members-console-ui-wiring.md
+++ b/docs/phase5-members-console-ui-wiring.md
@@ -1,0 +1,49 @@
+# Phase 5 Members Console UI Wiring
+
+Use `createPhase5MembersConsoleUiFlow` as the controller for Prompt 5 admin Members Console.
+
+## Flow contract
+
+- `load(gymId, options)`:
+  - Loads queue snapshot via `createPhase2StaffConsoleUiFlow.load(...)`.
+  - Loads profile + billing + check-in signals.
+  - Returns segmented/searchable rows, column preset visibility, queue summary, and selected profile panel timeline.
+- `assignRole(gymId, membershipId, role, auditNote, options)`:
+  - Requires non-empty audit note.
+  - Uses phase2 assignment mutation contract.
+  - Reloads full members snapshot.
+- `setStatus(gymId, membershipId, status, options)`:
+  - Uses phase2 membership status mutation for `trial|active|paused|cancelled`.
+  - Uses `B2BOpsService.upsertMemberSubscription(...)` for `past_due`.
+  - Reloads full members snapshot.
+- `bulkAssignRole(...)` and `bulkSetStatus(...)`:
+  - Process selected memberships.
+  - Return both `updatedMembershipIds` and `failedMembershipIds`.
+  - Reload full snapshot after execution.
+
+## UI requirements mapped
+
+- Member search: `options.search`
+- Segmented filters: `options.segment` (`all`, `pending`, `trial`, `active`, `past_due`, `paused`, `cancelled`)
+- Role filters: `options.roles`
+- Column visibility presets: `options.columnPreset` (`default`, `operations`, `billing`, `compliance`)
+- Profile side panel timeline: `snapshot.selectedProfilePanel.timeline`
+- Sticky header + bulk actions + audit-note gate:
+  - `snapshot.tableUx.stickyHeader`
+  - `snapshot.tableUx.supportsBulkActions`
+  - `snapshot.tableUx.requiresAuditNoteForRoleChange`
+
+## Error handling
+
+- All operations return explicit `ok: false` with:
+  - `error.code`
+  - `error.step`
+  - `error.message`
+  - `error.recoverable`
+
+Common UI-targeted codes:
+
+- `MEMBERS_CONSOLE_AUDIT_NOTE_REQUIRED`
+- `MEMBERS_CONSOLE_MEMBERSHIP_NOT_FOUND`
+- `ADMIN_STAFF_ACCESS_DENIED`
+- `ADMIN_AUTH_REQUIRED`

--- a/docs/phase5-runtime.md
+++ b/docs/phase5-runtime.md
@@ -11,6 +11,7 @@ Phase 5 runtime now includes an admin service layer for B2B daily operations:
 ## Admin entrypoints
 
 - `apps/admin/src/services/b2b-ops-service.ts`
+- `apps/admin/src/flows/phase5-members-console-ui.ts`
 - `apps/admin/src/flows/phase5-b2b-ops.ts`
 - `apps/admin/src/flows/phase5-ops-console-ui.ts`
 - `apps/admin/src/app/page.ts`
@@ -33,6 +34,11 @@ Core methods:
 
 UI controller methods:
 
+- `createPhase5MembersConsoleUiFlow.load(...)`
+- `createPhase5MembersConsoleUiFlow.assignRole(...)`
+- `createPhase5MembersConsoleUiFlow.setStatus(...)`
+- `createPhase5MembersConsoleUiFlow.bulkAssignRole(...)`
+- `createPhase5MembersConsoleUiFlow.bulkSetStatus(...)`
 - `createPhase5OpsConsoleUiFlow.load(...)`
 - `createPhase5OpsConsoleUiFlow.createClass(...)`
 - `createPhase5OpsConsoleUiFlow.upsertClassBooking(...)`

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -202,6 +202,14 @@
 147. `data_aggregation_jobs` and `data_anonymization_checks` are restricted to platform analytics/governance operators.
 148. `data_release_approvals` enforce one row per required approval type per export.
 
+## Phase 5 Members Console UI
+
+149. `createPhase5MembersConsoleUiFlow.load` returns searchable segmented rows with queue summary and column preset visibility.
+150. Role change actions (`assignRole`, `bulkAssignRole`) fail with `MEMBERS_CONSOLE_AUDIT_NOTE_REQUIRED` when audit note is missing.
+151. `setStatus` and `bulkSetStatus` support `past_due` by upserting member subscription status via `B2BOpsService`.
+152. Bulk actions return partial success metadata (`updatedMembershipIds`, `failedMembershipIds`) and refreshed snapshots.
+153. Selected profile side panel returns timeline entries from membership, check-in, subscription, and open privacy request signals.
+
 ## Performance targets for pilot
 
 - Feed p95 load < 500ms for 50-card page.


### PR DESCRIPTION
## Summary
- add createPhase5MembersConsoleUiFlow for Prompt 5 desktop Members Console
- add searchable and segmented member rows with bulk status and role actions
- enforce audit note requirement for all role-change actions
- compose createPhase2StaffConsoleUiFlow queue and refresh behavior with B2BOpsService subscription updates
- extend GymAdminService with staff-scoped member profile queries for side panel timelines
- add runtime docs and wiring guide updates for phase5 members console

## Validation
- npx tsc -p apps/admin/tsconfig.json --noEmit
- npx tsc -p apps/mobile/tsconfig.json --noEmit
- pnpm typecheck not available in this environment (pnpm command missing)

## Notes
- past_due action maps to member subscription status via B2BOpsService.upsertMemberSubscription
- bulk actions return updatedMembershipIds and failedMembershipIds for partial success handling