### PR TITLE
feat: CRUD actions for Members and Classes pages

### DIFF
--- a/apps/admin/src/app/(dashboard)/classes/page.tsx
+++ b/apps/admin/src/app/(dashboard)/classes/page.tsx
@@ -1,98 +1,99 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import { PageHeader } from "@/components/page-header";
 import { StatCard } from "@/components/stat-card";
 import { DataTable, type Column } from "@/components/data-table";
 import { StatusBadge, statusToVariant } from "@/components/status-badge";
 import { ErrorBanner } from "@/components/error-banner";
 import { PageSkeleton } from "@/components/loading-skeleton";
+import { Modal } from "@/components/modal";
 import { useGym } from "@/contexts/gym-context";
 import { useServices } from "@/hooks/use-services";
 import { useAsync } from "@/hooks/use-async";
 import type { GymClass } from "@kruxt/types";
 
-const columns: Column<GymClass>[] = [
-  {
-    key: "title",
-    header: "Class",
-    sortable: true,
-    render: (row) => (
-      <div>
-        <p className="font-medium text-foreground">{row.title}</p>
-        <p className="text-xs text-muted-foreground">{row.description ?? ""}</p>
-      </div>
-    ),
-  },
-  {
-    key: "coachUserId",
-    header: "Coach",
-    render: (row) => (
-      <span className="text-sm text-muted-foreground">{row.coachUserId ?? "—"}</span>
-    ),
-  },
-  {
-    key: "startsAt",
-    header: "Schedule",
-    render: (row) => (
-      <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
-        {row.startsAt
-          ? new Date(row.startsAt).toLocaleDateString("en-US", { weekday: "short", hour: "2-digit", minute: "2-digit" })
-          : "—"}
-      </span>
-    ),
-  },
-  {
-    key: "capacity",
-    header: "Capacity",
-    render: (row) => {
-      const cap = row.capacity ?? 0;
-      const booked = 0; // Booking count would come from a separate query
-      const pct = cap > 0 ? (booked / cap) * 100 : 0;
-      return (
-        <div className="flex items-center gap-2">
-          <div className="h-1.5 w-16 rounded-full bg-kruxt-panel">
-            <div
-              className={`h-full rounded-full ${
-                pct >= 100 ? "bg-kruxt-danger" : pct >= 80 ? "bg-kruxt-warning" : "bg-kruxt-accent"
-              }`}
-              style={{ width: `${Math.min(pct, 100)}%` }}
-            />
-          </div>
-          <span className="text-xs tabular-nums text-muted-foreground font-kruxt-mono">
-            {booked}/{cap}
-          </span>
-        </div>
-      );
-    },
-  },
-  {
-    key: "status",
-    header: "Status",
-    render: (row) => (
-      <StatusBadge label={row.status} variant={statusToVariant(row.status)} dot />
-    ),
-  },
-  {
-    key: "actions",
-    header: "",
-    className: "w-12",
-    render: () => (
-      <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-kruxt-panel hover:text-foreground">
-        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM12.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM18.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
-        </svg>
-      </button>
-    ),
-  },
-];
+const INPUT =
+  "w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent/40";
+
+interface CreateClassForm {
+  title: string;
+  description: string;
+  capacity: string;
+  startsAt: string;
+  endsAt: string;
+  coachUserId: string;
+}
+
+const defaultForm: CreateClassForm = {
+  title: "",
+  description: "",
+  capacity: "20",
+  startsAt: "",
+  endsAt: "",
+  coachUserId: "",
+};
 
 export default function ClassesPage() {
   const { gymId } = useGym();
   const { ops } = useServices();
+  const [showCreate, setShowCreate] = useState(false);
+  const [form, setForm] = useState<CreateClassForm>(defaultForm);
+  const [createLoading, setCreateLoading] = useState(false);
+  const [createError, setCreateError] = useState<string | undefined>();
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
+  const [cancelError, setCancelError] = useState<string | undefined>();
 
   const { status, data, error, refetch } = useAsync(
     () => ops.listGymClasses(gymId),
     [gymId]
+  );
+
+  const handleCreate = async () => {
+    if (!form.title.trim() || !form.startsAt || !form.endsAt || !form.capacity) {
+      setCreateError("Title, start time, end time, and capacity are required.");
+      return;
+    }
+    const cap = parseInt(form.capacity, 10);
+    if (isNaN(cap) || cap < 1) {
+      setCreateError("Capacity must be a positive number.");
+      return;
+    }
+    setCreateLoading(true);
+    setCreateError(undefined);
+    try {
+      await ops.createGymClass(gymId, {
+        title: form.title.trim(),
+        description: form.description.trim() || undefined,
+        capacity: cap,
+        startsAt: new Date(form.startsAt).toISOString(),
+        endsAt: new Date(form.endsAt).toISOString(),
+        coachUserId: form.coachUserId.trim() || undefined,
+      });
+      setShowCreate(false);
+      setForm(defaultForm);
+      refetch();
+    } catch (e) {
+      setCreateError(e instanceof Error ? e.message : "Failed to create class");
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  const handleCancel = useCallback(
+    async (classId: string) => {
+      setCancellingId(classId);
+      setCancelError(undefined);
+      try {
+        await ops.updateGymClass(gymId, classId, { status: "cancelled" });
+        refetch();
+      } catch (e) {
+        setCancelError(e instanceof Error ? e.message : "Failed to cancel class");
+      } finally {
+        setCancellingId(null);
+      }
+    },
+    [ops, gymId, refetch]
   );
 
   if (status === "loading" || status === "idle") return <PageSkeleton />;
@@ -100,7 +101,10 @@ export default function ClassesPage() {
   if (status === "error") {
     return (
       <div className="space-y-6">
-        <PageHeader title="Classes" description="Manage class schedules, instructors, and capacity." />
+        <PageHeader
+          title="Classes"
+          description="Manage class schedules, instructors, and capacity."
+        />
         <ErrorBanner message={error} onRetry={refetch} />
       </div>
     );
@@ -109,7 +113,79 @@ export default function ClassesPage() {
   const classes = data ?? [];
   const activeCount = classes.filter((c) => c.status === "scheduled").length;
   const totalCapacity = classes.reduce((sum, c) => sum + (c.capacity ?? 0), 0);
-  const totalBooked = 0; // Would need to aggregate bookings separately
+
+  const columns: Column<GymClass>[] = [
+    {
+      key: "title",
+      header: "Class",
+      sortable: true,
+      render: (row) => (
+        <div>
+          <p className="font-medium text-foreground">{row.title}</p>
+          <p className="text-xs text-muted-foreground">{row.description ?? ""}</p>
+        </div>
+      ),
+    },
+    {
+      key: "coachUserId",
+      header: "Coach",
+      render: (row) => (
+        <span className="text-sm text-muted-foreground">
+          {row.coachUserId ? row.coachUserId.slice(0, 8) : "—"}
+        </span>
+      ),
+    },
+    {
+      key: "startsAt",
+      header: "Schedule",
+      render: (row) => (
+        <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
+          {row.startsAt
+            ? new Date(row.startsAt).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+              })
+            : "—"}
+        </span>
+      ),
+    },
+    {
+      key: "capacity",
+      header: "Capacity",
+      render: (row) => (
+        <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
+          {row.capacity ?? "—"}
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (row) => (
+        <StatusBadge label={row.status} variant={statusToVariant(row.status)} dot />
+      ),
+    },
+    {
+      key: "actions",
+      header: "",
+      className: "w-28",
+      render: (row) => {
+        if (row.status !== "scheduled") return null;
+        const isCancelling = cancellingId === row.id;
+        return (
+          <button
+            onClick={() => handleCancel(row.id)}
+            disabled={isCancelling}
+            className="rounded-button border border-kruxt-danger/40 px-2.5 py-1 text-xs font-medium text-kruxt-danger transition-colors hover:bg-kruxt-danger/10 disabled:opacity-50"
+          >
+            {isCancelling ? "Cancelling…" : "Cancel"}
+          </button>
+        );
+      },
+    },
+  ];
 
   return (
     <div className="space-y-6">
@@ -117,30 +193,35 @@ export default function ClassesPage() {
         title="Classes"
         description="Manage class schedules, instructors, and capacity."
         actions={
-          <button className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90">
-            Create Class
+          <button
+            onClick={() => setShowCreate(true)}
+            className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90"
+          >
+            + Create Class
           </button>
         }
       />
 
+      {cancelError && (
+        <ErrorBanner message={cancelError} onRetry={() => setCancelError(undefined)} />
+      )}
+
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <StatCard label="Active Classes" value={activeCount} />
+        <StatCard label="Scheduled Classes" value={activeCount} />
         <StatCard
-          label="Total Bookings"
-          value={totalBooked}
-          subtext={`of ${totalCapacity} capacity`}
+          label="Total Capacity"
+          value={totalCapacity}
+          subtext="spots across all scheduled classes"
           accent="success"
         />
-        <StatCard
-          label="Avg Fill Rate"
-          value={totalCapacity > 0 ? `${Math.round((totalBooked / totalCapacity) * 100)}%` : "0%"}
-          accent="default"
-        />
+        <StatCard label="Total Classes" value={classes.length} accent="default" />
       </div>
 
       {classes.length === 0 ? (
         <div className="rounded-card border border-border bg-card p-8 text-center">
-          <p className="text-sm text-muted-foreground">No classes yet. Create your first class to get started.</p>
+          <p className="text-sm text-muted-foreground">
+            No classes yet. Create your first class to get started.
+          </p>
         </div>
       ) : (
         <DataTable
@@ -151,6 +232,120 @@ export default function ClassesPage() {
           searchPlaceholder="Search classes..."
         />
       )}
+
+      {/* Create Class Modal */}
+      <Modal
+        open={showCreate}
+        onClose={() => {
+          setShowCreate(false);
+          setForm(defaultForm);
+          setCreateError(undefined);
+        }}
+        title="Create Class"
+        size="md"
+        footer={
+          <>
+            <button
+              onClick={() => {
+                setShowCreate(false);
+                setForm(defaultForm);
+                setCreateError(undefined);
+              }}
+              className="rounded-button border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-kruxt-panel"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={createLoading}
+              className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {createLoading ? "Creating…" : "Create Class"}
+            </button>
+          </>
+        }
+      >
+        {createError && (
+          <p className="rounded-lg bg-kruxt-danger/10 px-3 py-2 text-xs text-kruxt-danger">
+            {createError}
+          </p>
+        )}
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            Title *
+          </label>
+          <input
+            type="text"
+            placeholder="e.g. Morning HIIT"
+            value={form.title}
+            onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+            className={INPUT}
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            Description
+          </label>
+          <textarea
+            rows={2}
+            placeholder="Optional class description…"
+            value={form.description}
+            onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+            className={INPUT}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Start *
+            </label>
+            <input
+              type="datetime-local"
+              value={form.startsAt}
+              onChange={(e) => setForm((f) => ({ ...f, startsAt: e.target.value }))}
+              className={INPUT}
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              End *
+            </label>
+            <input
+              type="datetime-local"
+              value={form.endsAt}
+              onChange={(e) => setForm((f) => ({ ...f, endsAt: e.target.value }))}
+              className={INPUT}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Capacity *
+            </label>
+            <input
+              type="number"
+              min={1}
+              placeholder="20"
+              value={form.capacity}
+              onChange={(e) => setForm((f) => ({ ...f, capacity: e.target.value }))}
+              className={INPUT}
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Coach User ID
+            </label>
+            <input
+              type="text"
+              placeholder="Optional UUID…"
+              value={form.coachUserId}
+              onChange={(e) => setForm((f) => ({ ...f, coachUserId: e.target.value }))}
+              className={INPUT}
+            />
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/apps/admin/src/app/(dashboard)/members/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { PageHeader } from "@/components/page-header";
 import { StatCard } from "@/components/stat-card";
 import { DataTable, type Column } from "@/components/data-table";
@@ -8,114 +8,95 @@ import { StatusBadge, statusToVariant } from "@/components/status-badge";
 import { EmptyState } from "@/components/empty-state";
 import { ErrorBanner } from "@/components/error-banner";
 import { PageSkeleton } from "@/components/loading-skeleton";
+import { Modal } from "@/components/modal";
 import { useGym } from "@/contexts/gym-context";
 import { useServices } from "@/hooks/use-services";
 import { useAsync } from "@/hooks/use-async";
-import type { GymMembership } from "@kruxt/types";
+import type { GymMembership, MembershipStatus, GymRole } from "@kruxt/types";
 
-type StatusFilter = "all" | "active" | "pending" | "trial" | "suspended" | "cancelled";
+const INPUT =
+  "w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent/40";
+
+type StatusFilter = "all" | MembershipStatus;
 
 const statusFilters: { value: StatusFilter; label: string }[] = [
   { value: "all", label: "All" },
   { value: "active", label: "Active" },
   { value: "pending", label: "Pending" },
   { value: "trial", label: "Trial" },
-  { value: "suspended", label: "Suspended" },
+  { value: "paused", label: "Paused" },
   { value: "cancelled", label: "Cancelled" },
 ];
 
-const columns: Column<GymMembership>[] = [
-  {
-    key: "name",
-    header: "Member",
-    sortable: true,
-    render: (row) => (
-      <div>
-        <p className="font-medium text-foreground">
-          {row.userId.slice(0, 8)}
-        </p>
-        <p className="text-xs text-muted-foreground">{row.userId}</p>
-      </div>
-    ),
-  },
-  {
-    key: "role",
-    header: "Role",
-    render: (row) => (
-      <span className="text-sm capitalize text-muted-foreground">{row.role}</span>
-    ),
-  },
-  {
-    key: "membershipStatus",
-    header: "Status",
-    render: (row) => (
-      <StatusBadge
-        label={row.membershipStatus}
-        variant={statusToVariant(row.membershipStatus)}
-        dot
-      />
-    ),
-  },
-  {
-    key: "startedAt",
-    header: "Started",
-    sortable: true,
-    render: (row) => (
-      <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
-        {row.startedAt
-          ? new Date(row.startedAt).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            })
-          : "—"}
-      </span>
-    ),
-  },
-  {
-    key: "endsAt",
-    header: "Ends",
-    render: (row) =>
-      row.endsAt ? (
-        <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
-          {new Date(row.endsAt).toLocaleDateString("en-US", {
-            month: "short",
-            day: "numeric",
-            year: "numeric",
-          })}
-        </span>
-      ) : (
-        <span className="text-xs text-muted-foreground">—</span>
-      ),
-  },
-  {
-    key: "actions",
-    header: "",
-    className: "w-12",
-    render: () => (
-      <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-kruxt-panel hover:text-foreground">
-        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM12.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM18.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
-        </svg>
-      </button>
-    ),
-  },
-];
+interface AddMemberForm {
+  userId: string;
+  role: GymRole;
+  membershipStatus: MembershipStatus;
+}
+
+const defaultAddForm: AddMemberForm = {
+  userId: "",
+  role: "member",
+  membershipStatus: "active",
+};
 
 export default function MembersPage() {
   const { gymId } = useGym();
   const { gym } = useServices();
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [search, setSearch] = useState("");
+  const [showAdd, setShowAdd] = useState(false);
+  const [addForm, setAddForm] = useState<AddMemberForm>(defaultAddForm);
+  const [addLoading, setAddLoading] = useState(false);
+  const [addError, setAddError] = useState<string | undefined>();
+  const [actionId, setActionId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | undefined>();
 
   const { status, data, error, refetch } = useAsync(
     () => gym.listGymMemberships(gymId),
     [gymId]
   );
 
-  if (status === "loading" || status === "idle") {
-    return <PageSkeleton />;
-  }
+  const handleAddMember = async () => {
+    if (!addForm.userId.trim()) {
+      setAddError("User ID is required.");
+      return;
+    }
+    setAddLoading(true);
+    setAddError(undefined);
+    try {
+      await gym.addOrUpdateMembership(gymId, {
+        userId: addForm.userId.trim(),
+        role: addForm.role,
+        membershipStatus: addForm.membershipStatus,
+      });
+      setShowAdd(false);
+      setAddForm(defaultAddForm);
+      refetch();
+    } catch (e) {
+      setAddError(e instanceof Error ? e.message : "Failed to add member");
+    } finally {
+      setAddLoading(false);
+    }
+  };
+
+  const handleStatusChange = useCallback(
+    async (membershipId: string, newStatus: MembershipStatus) => {
+      setActionId(membershipId);
+      setActionError(undefined);
+      try {
+        await gym.updateMembershipStatus(gymId, membershipId, newStatus);
+        refetch();
+      } catch (e) {
+        setActionError(e instanceof Error ? e.message : "Action failed");
+      } finally {
+        setActionId(null);
+      }
+    },
+    [gym, gymId, refetch]
+  );
+
+  if (status === "loading" || status === "idle") return <PageSkeleton />;
 
   if (status === "error") {
     return (
@@ -141,19 +122,132 @@ export default function MembersPage() {
   const pendingCount = members.filter((m) => m.membershipStatus === "pending").length;
   const trialCount = members.filter((m) => m.membershipStatus === "trial").length;
 
+  const columns: Column<GymMembership>[] = [
+    {
+      key: "name",
+      header: "Member",
+      sortable: true,
+      render: (row) => (
+        <div>
+          <p className="font-medium text-foreground">{row.userId.slice(0, 8)}</p>
+          <p className="text-xs text-muted-foreground">{row.userId}</p>
+        </div>
+      ),
+    },
+    {
+      key: "role",
+      header: "Role",
+      render: (row) => (
+        <span className="text-sm capitalize text-muted-foreground">{row.role}</span>
+      ),
+    },
+    {
+      key: "membershipStatus",
+      header: "Status",
+      render: (row) => (
+        <StatusBadge
+          label={row.membershipStatus}
+          variant={statusToVariant(row.membershipStatus)}
+          dot
+        />
+      ),
+    },
+    {
+      key: "startedAt",
+      header: "Started",
+      sortable: true,
+      render: (row) => (
+        <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
+          {row.startedAt
+            ? new Date(row.startedAt).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })
+            : "—"}
+        </span>
+      ),
+    },
+    {
+      key: "endsAt",
+      header: "Ends",
+      render: (row) =>
+        row.endsAt ? (
+          <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
+            {new Date(row.endsAt).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })}
+          </span>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
+    },
+    {
+      key: "actions",
+      header: "",
+      className: "w-32",
+      render: (row) => {
+        const loading = actionId === row.id;
+        if (row.membershipStatus === "pending") {
+          return (
+            <button
+              onClick={() => handleStatusChange(row.id, "active")}
+              disabled={loading}
+              className="rounded-button bg-kruxt-success/15 px-2.5 py-1 text-xs font-medium text-kruxt-success transition-colors hover:bg-kruxt-success/25 disabled:opacity-50"
+            >
+              {loading ? "…" : "Approve"}
+            </button>
+          );
+        }
+        if (row.membershipStatus === "active" || row.membershipStatus === "trial") {
+          return (
+            <button
+              onClick={() => handleStatusChange(row.id, "paused")}
+              disabled={loading}
+              className="rounded-button border border-kruxt-warning/40 px-2.5 py-1 text-xs font-medium text-kruxt-warning transition-colors hover:bg-kruxt-warning/10 disabled:opacity-50"
+            >
+              {loading ? "…" : "Pause"}
+            </button>
+          );
+        }
+        if (row.membershipStatus === "paused") {
+          return (
+            <button
+              onClick={() => handleStatusChange(row.id, "active")}
+              disabled={loading}
+              className="rounded-button bg-kruxt-accent/15 px-2.5 py-1 text-xs font-medium text-kruxt-accent transition-colors hover:bg-kruxt-accent/25 disabled:opacity-50"
+            >
+              {loading ? "…" : "Reactivate"}
+            </button>
+          );
+        }
+        return null;
+      },
+    },
+  ];
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Members"
         description="Manage gym memberships, roles, and access."
         actions={
-          <button className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90">
-            Add Member
+          <button
+            onClick={() => setShowAdd(true)}
+            className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90"
+          >
+            + Add Member
           </button>
         }
       />
 
-      {/* Stats row */}
+      {actionError && (
+        <ErrorBanner message={actionError} onRetry={() => setActionError(undefined)} />
+      )}
+
+      {/* Stats */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <StatCard label="Active Members" value={activeCount} accent="success" />
         <StatCard label="Pending Approval" value={pendingCount} accent="warning" />
@@ -177,10 +271,19 @@ export default function MembersPage() {
             </button>
           ))}
         </div>
-
         <div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5">
-          <svg className="h-4 w-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+          <svg
+            className="h-4 w-4 text-muted-foreground"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+            />
           </svg>
           <input
             type="text"
@@ -202,8 +305,18 @@ export default function MembersPage() {
               : "Try adjusting your filters or search terms."
           }
           icon={
-            <svg className="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
+            <svg
+              className="h-10 w-10"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+              />
             </svg>
           }
         />
@@ -214,6 +327,89 @@ export default function MembersPage() {
           keyExtractor={(row) => row.id}
         />
       )}
+
+      {/* Add Member Modal */}
+      <Modal
+        open={showAdd}
+        onClose={() => {
+          setShowAdd(false);
+          setAddForm(defaultAddForm);
+          setAddError(undefined);
+        }}
+        title="Add Member"
+        size="sm"
+        footer={
+          <>
+            <button
+              onClick={() => {
+                setShowAdd(false);
+                setAddForm(defaultAddForm);
+                setAddError(undefined);
+              }}
+              className="rounded-button border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-kruxt-panel"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleAddMember}
+              disabled={addLoading}
+              className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {addLoading ? "Adding…" : "Add Member"}
+            </button>
+          </>
+        }
+      >
+        {addError && (
+          <p className="rounded-lg bg-kruxt-danger/10 px-3 py-2 text-xs text-kruxt-danger">
+            {addError}
+          </p>
+        )}
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            User ID *
+          </label>
+          <input
+            type="text"
+            placeholder="Supabase user UUID…"
+            value={addForm.userId}
+            onChange={(e) => setAddForm((f) => ({ ...f, userId: e.target.value }))}
+            className={INPUT}
+          />
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            Find the user&apos;s UUID in Supabase → Authentication → Users
+          </p>
+        </div>
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Role</label>
+          <select
+            value={addForm.role}
+            onChange={(e) => setAddForm((f) => ({ ...f, role: e.target.value as GymRole }))}
+            className={INPUT}
+          >
+            <option value="member">Member</option>
+            <option value="coach">Coach</option>
+            <option value="officer">Officer</option>
+            <option value="leader">Leader</option>
+          </select>
+        </div>
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+            Initial Status
+          </label>
+          <select
+            value={addForm.membershipStatus}
+            onChange={(e) =>
+              setAddForm((f) => ({ ...f, membershipStatus: e.target.value as MembershipStatus }))
+            }
+            className={INPUT}
+          >
+            <option value="active">Active</option>
+            <option value="trial">Trial</option>
+            <option value="pending">Pending (requires approval)</option>
+          </select>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/apps/admin/src/components/modal.tsx
+++ b/apps/admin/src/components/modal.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, type ReactNode } from "react";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  size?: "sm" | "md" | "lg";
+}
+
+export function Modal({ open, onClose, title, children, footer, size = "md" }: ModalProps) {
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const maxWidths = { sm: "max-w-sm", md: "max-w-md", lg: "max-w-lg" };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      {/* Card */}
+      <div
+        className={`relative w-full ${maxWidths[size]} rounded-card border border-border bg-kruxt-surface shadow-2xl`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-6 py-4">
+          <h2
+            id="modal-title"
+            className="text-sm font-semibold uppercase tracking-wider text-foreground font-kruxt-headline"
+          >
+            {title}
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-kruxt-panel hover:text-foreground"
+            aria-label="Close"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        {/* Body */}
+        <div className="space-y-4 px-6 py-5">{children}</div>
+        {/* Footer */}
+        {footer && (
+          <div className="flex justify-end gap-3 border-t border-border px-6 py-4">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Members**: Add Member modal (userId + role + status) + per-row Approve / Pause / Reactivate buttons wired to real service calls
- **Classes**: Create Class modal (title, schedule, capacity, coach) + per-row Cancel button; row shows spinner during in-flight action
- **Shared**: New `Modal` component (Escape-to-close, backdrop click, accessible `role=dialog`)
- **Bug fix**: Members status filter corrected from `"suspended"` → `"paused"` to match the actual `MembershipStatus` type

## Test plan
- [ ] Set `NEXT_PUBLIC_SUPABASE_URL` + `NEXT_PUBLIC_SUPABASE_ANON_KEY` in `apps/admin/.env.local`
- [ ] `cd apps/admin && pnpm dev` → open http://localhost:3000
- [ ] Members: click "+ Add Member", fill UUID, submit, verify row appears
- [ ] Members: click Approve/Pause/Reactivate on a row, verify status badge updates
- [ ] Classes: click "+ Create Class", fill form, submit, verify class appears in table
- [ ] Classes: click Cancel on a scheduled class, verify status changes to cancelled
- [ ] Verify error states show correctly when Supabase calls fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)