### PR TITLE
feat: real Supabase auth + auto gym discovery

### DIFF
--- a/apps/admin/src/app/(auth)/login/page.tsx
+++ b/apps/admin/src/app/(auth)/login/page.tsx
@@ -2,29 +2,62 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/auth-context";
+import { createAdminSupabaseClient } from "@/services";
+
+type Mode = "signin" | "signup";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const { signIn } = useAuth();
+  const [mode, setMode] = useState<Mode>("signin");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
-    setLoading(true);
-
-    // TODO: Wire to Supabase auth
-    await new Promise((resolve) => setTimeout(resolve, 800));
+    setInfo(null);
 
     if (!email || !password) {
       setError("Email and password are required.");
-      setLoading(false);
       return;
     }
 
-    // Simulate login -- replace with real auth
-    window.location.href = "/";
+    setLoading(true);
+    try {
+      if (mode === "signin") {
+        const result = await signIn(email, password);
+        if (result.error) {
+          setError(result.error);
+        } else {
+          router.replace("/");
+        }
+      } else {
+        const supabase = createAdminSupabaseClient();
+        const { data, error: signUpError } = await supabase.auth.signUp({
+          email,
+          password,
+        });
+        if (signUpError) {
+          setError(signUpError.message);
+        } else if (data.session) {
+          router.replace("/");
+        } else {
+          setInfo("Account created. Check your email to confirm, then sign in.");
+          setMode("signin");
+          setPassword("");
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Authentication failed.");
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
@@ -34,23 +67,62 @@ export default function LoginPage() {
         <h1 className="text-3xl font-bold tracking-tight text-kruxt-accent font-kruxt-headline">
           KRUXT
         </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Admin Dashboard
-        </p>
+        <p className="mt-1 text-sm text-muted-foreground">Admin Dashboard</p>
       </div>
 
       {/* Form card */}
       <div className="rounded-card border border-border bg-card p-6">
-        <h2 className="text-lg font-semibold text-foreground font-kruxt-headline">
-          Sign in to your account
+        {/* Mode switcher */}
+        <div className="flex items-center gap-1 rounded-lg border border-border bg-kruxt-panel p-1 text-xs">
+          <button
+            type="button"
+            onClick={() => {
+              setMode("signin");
+              setError(null);
+              setInfo(null);
+            }}
+            className={`flex-1 rounded-md px-3 py-1.5 font-medium transition-colors ${
+              mode === "signin"
+                ? "bg-kruxt-accent/15 text-kruxt-accent"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Sign in
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setMode("signup");
+              setError(null);
+              setInfo(null);
+            }}
+            className={`flex-1 rounded-md px-3 py-1.5 font-medium transition-colors ${
+              mode === "signup"
+                ? "bg-kruxt-accent/15 text-kruxt-accent"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Sign up
+          </button>
+        </div>
+
+        <h2 className="mt-5 text-lg font-semibold text-foreground font-kruxt-headline">
+          {mode === "signin" ? "Sign in to your account" : "Create a new account"}
         </h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Enter your credentials to access the admin panel.
+          {mode === "signin"
+            ? "Enter your credentials to access the admin panel."
+            : "Use a real email — Supabase may send a confirmation link."}
         </p>
 
         {error && (
           <div className="mt-4 rounded-lg border border-kruxt-danger/30 bg-kruxt-danger/10 px-4 py-3 text-sm text-kruxt-danger">
             {error}
+          </div>
+        )}
+        {info && (
+          <div className="mt-4 rounded-lg border border-kruxt-accent/30 bg-kruxt-accent/10 px-4 py-3 text-sm text-kruxt-accent">
+            {info}
           </div>
         )}
 
@@ -70,7 +142,7 @@ export default function LoginPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               className="mt-1.5 w-full rounded-button border border-border bg-kruxt-panel px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent"
-              placeholder="admin@gym.com"
+              placeholder="you@example.com"
             />
           </div>
 
@@ -84,12 +156,13 @@ export default function LoginPage() {
             <input
               id="password"
               type="password"
-              autoComplete="current-password"
+              autoComplete={mode === "signin" ? "current-password" : "new-password"}
               required
+              minLength={6}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               className="mt-1.5 w-full rounded-button border border-border bg-kruxt-panel px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent"
-              placeholder="Enter your password"
+              placeholder="••••••••"
             />
           </div>
 
@@ -98,18 +171,24 @@ export default function LoginPage() {
             disabled={loading}
             className="w-full rounded-button bg-kruxt-accent px-4 py-2.5 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
           >
-            {loading ? "Signing in..." : "Sign In"}
+            {loading
+              ? "Working…"
+              : mode === "signin"
+                ? "Sign In"
+                : "Create account"}
           </button>
         </form>
 
-        <div className="mt-4 text-center">
-          <Link
-            href="/forgot-password"
-            className="text-xs text-kruxt-accent hover:underline"
-          >
-            Forgot your password?
-          </Link>
-        </div>
+        {mode === "signin" && (
+          <div className="mt-4 text-center">
+            <Link
+              href="/forgot-password"
+              className="text-xs text-kruxt-accent hover:underline"
+            >
+              Forgot your password?
+            </Link>
+          </div>
+        )}
       </div>
 
       {/* Brand footer */}

--- a/apps/admin/src/app/(dashboard)/layout.tsx
+++ b/apps/admin/src/app/(dashboard)/layout.tsx
@@ -1,17 +1,118 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Sidebar } from "@/components/sidebar";
 import { TopBar } from "@/components/top-bar";
+import { useAuth } from "@/contexts/auth-context";
+import { useGym } from "@/contexts/gym-context";
 import { cn } from "@/lib/utils";
+
+function FullPageLoader({ label }: { label?: string }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-kruxt-bg">
+      <div className="flex items-center gap-3 text-muted-foreground">
+        <svg className="h-5 w-5 animate-spin" viewBox="0 0 24 24" fill="none">
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+            className="opacity-25"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+        <span className="text-sm">{label ?? "Loading…"}</span>
+      </div>
+    </div>
+  );
+}
+
+function NoGymOnboarding({ onRefresh }: { onRefresh: () => void }) {
+  const { signOut, user } = useAuth();
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-kruxt-bg p-6">
+      <div className="w-full max-w-md rounded-card border border-border bg-card p-8">
+        <h1 className="text-xl font-bold text-foreground font-kruxt-headline">
+          No gym linked yet
+        </h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Your account ({user?.email}) isn&apos;t linked to a gym yet. To get
+          started, create a gym row in Supabase and add yourself to{" "}
+          <code className="rounded bg-kruxt-panel px-1 py-0.5 text-xs">
+            gym_memberships
+          </code>{" "}
+          with role <code className="rounded bg-kruxt-panel px-1 py-0.5 text-xs">leader</code>{" "}
+          and status{" "}
+          <code className="rounded bg-kruxt-panel px-1 py-0.5 text-xs">active</code>.
+        </p>
+        <ol className="mt-4 list-inside list-decimal space-y-1 text-xs text-muted-foreground">
+          <li>Open Supabase → Table Editor → <code>gyms</code></li>
+          <li>Insert a new row (note the generated <code>id</code>)</li>
+          <li>Open <code>gym_memberships</code> and insert a row with <code>gym_id</code> = your new gym, <code>user_id</code> = {user?.id ?? "your auth user id"}, <code>role</code> = <code>leader</code>, <code>membership_status</code> = <code>active</code></li>
+          <li>Click Refresh below</li>
+        </ol>
+        <div className="mt-6 flex gap-3">
+          <button
+            onClick={onRefresh}
+            className="flex-1 rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90"
+          >
+            Refresh
+          </button>
+          <button
+            onClick={() => signOut()}
+            className="rounded-button border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-kruxt-panel"
+          >
+            Sign out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { user, loading: authLoading } = useAuth();
+  const { loading: gymLoading, noGymFound, refresh } = useGym();
+  const router = useRouter();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.replace("/login");
+    }
+  }, [authLoading, user, router]);
+
+  // 1) Auth still resolving
+  if (authLoading) {
+    return <FullPageLoader label="Checking session…" />;
+  }
+
+  // 2) Not authed → redirect (placeholder while replace runs)
+  if (!user) {
+    return <FullPageLoader label="Redirecting to sign in…" />;
+  }
+
+  // 3) Auth'd but gym membership still loading
+  if (gymLoading) {
+    return <FullPageLoader label="Loading your gym…" />;
+  }
+
+  // 4) Auth'd but no gym linked
+  if (noGymFound) {
+    return <NoGymOnboarding onRefresh={refresh} />;
+  }
+
+  // 5) All set — render the dashboard
   return (
     <div className="min-h-screen bg-kruxt-bg">
       <Sidebar

--- a/apps/admin/src/contexts/gym-context.tsx
+++ b/apps/admin/src/contexts/gym-context.tsx
@@ -4,36 +4,110 @@ import {
   createContext,
   useContext,
   useState,
+  useEffect,
+  useCallback,
   type ReactNode,
 } from "react";
+import { useAuth } from "./auth-context";
+import { createAdminSupabaseClient } from "@/services";
 
 interface GymContextValue {
-  /** Currently selected gym ID */
+  /** Currently selected gym ID — empty string until loaded */
   gymId: string;
   /** Gym display name (for top bar, etc.) */
   gymName: string;
+  /** True while we're discovering the user's gym membership */
+  loading: boolean;
+  /** True if the auth'd user has no active gym membership */
+  noGymFound: boolean;
   /** Switch to a different gym tenant */
   setGym: (id: string, name: string) => void;
+  /** Re-fetch the user's gym membership */
+  refresh: () => void;
 }
 
 const GymContext = createContext<GymContextValue | null>(null);
 
 /**
- * Provides the current gym context to admin dashboard pages.
- * For now, defaults to a hardcoded gym. Once multi-gym support
- * is wired, this will read from the user's gym_memberships.
+ * Discovers the current user's first active gym membership and exposes the
+ * gym ID + display name to the dashboard. While the user has no gym yet,
+ * `noGymFound` flips true and the dashboard layout shows an onboarding panel.
  */
 export function GymProvider({ children }: { children: ReactNode }) {
-  const [gymId, setGymId] = useState("gym_01");
-  const [gymName, setGymName] = useState("Iron Temple Fitness");
+  const { user, loading: authLoading } = useAuth();
+  const [gymId, setGymId] = useState("");
+  const [gymName, setGymName] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [noGymFound, setNoGymFound] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!user) {
+      setGymId("");
+      setGymName("");
+      setNoGymFound(false);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setNoGymFound(false);
+    try {
+      const supabase = createAdminSupabaseClient();
+
+      // 1) Find the first active/trial gym membership for this user.
+      const { data: membership, error: membershipError } = await supabase
+        .from("gym_memberships")
+        .select("gym_id")
+        .eq("user_id", user.id)
+        .in("membership_status", ["active", "trial"])
+        .limit(1)
+        .maybeSingle();
+
+      if (membershipError) throw membershipError;
+
+      if (!membership) {
+        setNoGymFound(true);
+        setGymId("");
+        setGymName("");
+        return;
+      }
+
+      // 2) Fetch the gym's display name.
+      const { data: gym, error: gymError } = await supabase
+        .from("gyms")
+        .select("id, name")
+        .eq("id", membership.gym_id)
+        .maybeSingle();
+
+      if (gymError) throw gymError;
+
+      setGymId(membership.gym_id);
+      setGymName(gym?.name ?? "Your gym");
+    } catch (e) {
+      console.error("[GymProvider] failed to load gym:", e);
+      setNoGymFound(true);
+      setGymId("");
+      setGymName("");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!authLoading) {
+      refresh();
+    }
+  }, [authLoading, refresh]);
 
   function setGym(id: string, name: string) {
     setGymId(id);
     setGymName(name);
+    setNoGymFound(false);
   }
 
   return (
-    <GymContext.Provider value={{ gymId, gymName, setGym }}>
+    <GymContext.Provider
+      value={{ gymId, gymName, loading, noGymFound, setGym, refresh }}
+    >
       {children}
     </GymContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Login page now calls real Supabase auth (`signIn` via context, `auth.signUp` for new accounts) — replaces fake `window.location.href` redirect
- `GymProvider` auto-discovers the user's first active/trial `gym_membership` and joins to `gyms.name`
- Dashboard layout redirects unauthed users to `/login`, shows full-page loaders during auth/gym resolution, and renders a step-by-step "No gym linked yet" onboarding panel when the user has no gym

## Test plan
- [ ] `cd apps/admin && pnpm dev` → http://localhost:3000
- [ ] Hit `/` while signed out → redirects to `/login`
- [ ] Sign up new account → success info banner OR session created
- [ ] Sign in valid creds → lands on `/`
- [ ] If no gym membership → onboarding panel with instructions
- [ ] Once gym row exists → dashboard renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)