### PR TITLE
feat(foundation): coaching, join requests, manual payments, branding + UI primitives

### DIFF
--- a/packages/db/supabase/migrations/202605110001_member_coaching_and_workout_plans.sql
+++ b/packages/db/supabase/migrations/202605110001_member_coaching_and_workout_plans.sql
@@ -1,0 +1,609 @@
+-- Member coaching ownership and staff-authored workout plans.
+
+alter table public.gym_memberships
+  add column if not exists coach_user_id uuid references public.profiles(id) on delete set null;
+
+create index if not exists idx_gym_memberships_coach
+  on public.gym_memberships(gym_id, coach_user_id)
+  where coach_user_id is not null;
+
+create or replace function public.validate_gym_membership_coach()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.coach_user_id is null then
+    return new;
+  end if;
+
+  if new.coach_user_id = new.user_id then
+    raise exception 'A member cannot be assigned as their own coach';
+  end if;
+
+  if not exists (
+    select 1
+    from public.gym_memberships gm
+    where gm.gym_id = new.gym_id
+      and gm.user_id = new.coach_user_id
+      and gm.membership_status in ('trial', 'active')
+      and gm.role in ('leader', 'officer', 'coach')
+  ) then
+    raise exception 'Assigned coach must be active staff in the same gym';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_gym_memberships_validate_coach on public.gym_memberships;
+create trigger trg_gym_memberships_validate_coach
+before insert or update of coach_user_id, gym_id, user_id
+on public.gym_memberships
+for each row
+execute function public.validate_gym_membership_coach();
+
+create table if not exists public.gym_member_workout_plans (
+  id uuid primary key default gen_random_uuid(),
+  gym_id uuid not null references public.gyms(id) on delete cascade,
+  member_user_id uuid not null references public.profiles(id) on delete cascade,
+  coach_user_id uuid references public.profiles(id) on delete set null,
+  title text not null,
+  goal text,
+  status text not null default 'active'
+    check (status in ('draft', 'active', 'paused', 'completed', 'archived')),
+  starts_at date,
+  ends_at date,
+  plan_json jsonb not null default '{}'::jsonb,
+  created_by uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (ends_at is null or starts_at is null or ends_at >= starts_at)
+);
+
+create index if not exists idx_gym_member_workout_plans_member
+  on public.gym_member_workout_plans(gym_id, member_user_id, status, updated_at desc);
+
+create index if not exists idx_gym_member_workout_plans_coach
+  on public.gym_member_workout_plans(gym_id, coach_user_id, updated_at desc)
+  where coach_user_id is not null;
+
+create or replace function public.validate_gym_member_workout_plan_subjects()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (
+    select 1
+    from public.gym_memberships gm
+    where gm.gym_id = new.gym_id
+      and gm.user_id = new.member_user_id
+      and gm.membership_status in ('pending', 'trial', 'active', 'paused')
+  ) then
+    raise exception 'Workout plan member must belong to the same gym';
+  end if;
+
+  if new.coach_user_id is not null then
+    if new.coach_user_id = new.member_user_id then
+      raise exception 'A member cannot be assigned as their own workout plan coach';
+    end if;
+
+    if not exists (
+      select 1
+      from public.gym_memberships gm
+      where gm.gym_id = new.gym_id
+        and gm.user_id = new.coach_user_id
+        and gm.membership_status in ('trial', 'active')
+        and gm.role in ('leader', 'officer', 'coach')
+    ) then
+      raise exception 'Workout plan coach must be active staff in the same gym';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_gym_member_workout_plans_validate_subjects on public.gym_member_workout_plans;
+create trigger trg_gym_member_workout_plans_validate_subjects
+before insert or update of gym_id, member_user_id, coach_user_id
+on public.gym_member_workout_plans
+for each row
+execute function public.validate_gym_member_workout_plan_subjects();
+
+drop trigger if exists trg_gym_member_workout_plans_set_updated_at on public.gym_member_workout_plans;
+create trigger trg_gym_member_workout_plans_set_updated_at
+before update on public.gym_member_workout_plans
+for each row
+execute function public.set_updated_at();
+
+alter table public.gym_member_workout_plans enable row level security;
+
+drop policy if exists gym_member_workout_plans_select on public.gym_member_workout_plans;
+create policy gym_member_workout_plans_select
+on public.gym_member_workout_plans for select to authenticated
+using (
+  member_user_id = auth.uid()
+  or coach_user_id = auth.uid()
+  or public.is_gym_staff(gym_id, auth.uid())
+);
+
+drop policy if exists gym_member_workout_plans_insert on public.gym_member_workout_plans;
+create policy gym_member_workout_plans_insert
+on public.gym_member_workout_plans for insert to authenticated
+with check (public.is_gym_staff(gym_id, auth.uid()));
+
+drop policy if exists gym_member_workout_plans_update on public.gym_member_workout_plans;
+create policy gym_member_workout_plans_update
+on public.gym_member_workout_plans for update to authenticated
+using (public.is_gym_staff(gym_id, auth.uid()))
+with check (public.is_gym_staff(gym_id, auth.uid()));
+
+drop policy if exists gym_member_workout_plans_delete on public.gym_member_workout_plans;
+create policy gym_member_workout_plans_delete
+on public.gym_member_workout_plans for delete to authenticated
+using (public.is_gym_staff(gym_id, auth.uid()));
+
+create table if not exists public.gym_invite_codes (
+  id uuid primary key default gen_random_uuid(),
+  gym_id uuid not null references public.gyms(id) on delete cascade,
+  code text not null unique check (code ~ '^[A-Z0-9-]{4,64}$'),
+  label text,
+  role public.gym_role not null default 'member',
+  membership_status public.membership_status not null default 'active',
+  membership_plan_id uuid references public.gym_membership_plans(id) on delete set null,
+  max_redemptions integer check (max_redemptions is null or max_redemptions > 0),
+  redeemed_count integer not null default 0 check (redeemed_count >= 0),
+  expires_at timestamptz,
+  is_active boolean not null default true,
+  created_by uuid references public.profiles(id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (redeemed_count <= coalesce(max_redemptions, redeemed_count))
+);
+
+create index if not exists idx_gym_invite_codes_gym_active
+  on public.gym_invite_codes(gym_id, is_active, expires_at);
+
+create table if not exists public.gym_join_requests (
+  id uuid primary key default gen_random_uuid(),
+  gym_id uuid not null references public.gyms(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  requested_membership_plan_id uuid references public.gym_membership_plans(id) on delete set null,
+  source text not null default 'public_request'
+    check (source in ('public_request', 'invite_code', 'staff_created')),
+  invite_code_id uuid references public.gym_invite_codes(id) on delete set null,
+  status text not null default 'pending'
+    check (status in ('pending', 'approved', 'rejected', 'cancelled')),
+  note text,
+  staff_note text,
+  reviewed_by uuid references public.profiles(id) on delete set null,
+  reviewed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_gym_join_requests_gym_status
+  on public.gym_join_requests(gym_id, status, created_at desc);
+
+create index if not exists idx_gym_join_requests_user
+  on public.gym_join_requests(user_id, created_at desc);
+
+create unique index if not exists idx_gym_join_requests_one_pending
+  on public.gym_join_requests(gym_id, user_id)
+  where status = 'pending';
+
+create table if not exists public.gym_invite_code_redemptions (
+  id uuid primary key default gen_random_uuid(),
+  invite_code_id uuid not null references public.gym_invite_codes(id) on delete cascade,
+  gym_id uuid not null references public.gyms(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  membership_id uuid references public.gym_memberships(id) on delete set null,
+  redeemed_at timestamptz not null default now(),
+  unique(invite_code_id, user_id)
+);
+
+create index if not exists idx_gym_invite_code_redemptions_gym
+  on public.gym_invite_code_redemptions(gym_id, redeemed_at desc);
+
+drop trigger if exists trg_gym_invite_codes_set_updated_at on public.gym_invite_codes;
+create trigger trg_gym_invite_codes_set_updated_at
+before update on public.gym_invite_codes
+for each row
+execute function public.set_updated_at();
+
+drop trigger if exists trg_gym_join_requests_set_updated_at on public.gym_join_requests;
+create trigger trg_gym_join_requests_set_updated_at
+before update on public.gym_join_requests
+for each row
+execute function public.set_updated_at();
+
+create or replace function public.request_gym_membership(
+  p_gym_id uuid,
+  p_membership_plan_id uuid default null,
+  p_note text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_membership_id uuid;
+  v_membership_status public.membership_status;
+  v_request_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if not exists (select 1 from public.profiles p where p.id = v_user_id) then
+    raise exception 'Create your public profile before requesting gym access';
+  end if;
+
+  if not exists (select 1 from public.gyms g where g.id = p_gym_id and g.is_public = true) then
+    raise exception 'Gym is not available for public access requests';
+  end if;
+
+  if p_membership_plan_id is not null and not exists (
+    select 1
+    from public.gym_membership_plans gmp
+    where gmp.id = p_membership_plan_id
+      and gmp.gym_id = p_gym_id
+      and gmp.is_active = true
+  ) then
+    raise exception 'Membership plan is not available for this gym';
+  end if;
+
+  insert into public.gym_memberships(
+    gym_id,
+    user_id,
+    role,
+    membership_status,
+    membership_plan_id
+  )
+  values (
+    p_gym_id,
+    v_user_id,
+    'member',
+    'pending',
+    p_membership_plan_id
+  )
+  on conflict (gym_id, user_id) do update
+    set membership_plan_id = coalesce(excluded.membership_plan_id, public.gym_memberships.membership_plan_id),
+        membership_status = case
+          when public.gym_memberships.membership_status = 'cancelled' then 'pending'::public.membership_status
+          else public.gym_memberships.membership_status
+        end
+  returning id, membership_status
+  into v_membership_id, v_membership_status;
+
+  if v_membership_status in ('active', 'trial', 'paused') then
+    return v_membership_id;
+  end if;
+
+  update public.gym_join_requests gjr
+  set requested_membership_plan_id = coalesce(p_membership_plan_id, gjr.requested_membership_plan_id),
+      source = 'public_request',
+      note = nullif(trim(coalesce(p_note, '')), ''),
+      invite_code_id = null
+  where gjr.gym_id = p_gym_id
+    and gjr.user_id = v_user_id
+    and gjr.status = 'pending'
+  returning id
+  into v_request_id;
+
+  if v_request_id is null then
+    insert into public.gym_join_requests(
+      gym_id,
+      user_id,
+      requested_membership_plan_id,
+      source,
+      status,
+      note
+    )
+    values (
+      p_gym_id,
+      v_user_id,
+      p_membership_plan_id,
+      'public_request',
+      'pending',
+      nullif(trim(coalesce(p_note, '')), '')
+    )
+    returning id
+    into v_request_id;
+  end if;
+
+  return v_membership_id;
+end;
+$$;
+
+create or replace function public.redeem_gym_invite_code(
+  p_code text,
+  p_note text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_code text := upper(trim(coalesce(p_code, '')));
+  v_invite public.gym_invite_codes%rowtype;
+  v_membership_id uuid;
+  v_request_status text;
+  v_redemption_id uuid;
+  v_existing_request_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if not exists (select 1 from public.profiles p where p.id = v_user_id) then
+    raise exception 'Create your public profile before redeeming a gym invite';
+  end if;
+
+  select *
+  into v_invite
+  from public.gym_invite_codes gic
+  where gic.code = v_code
+  for update;
+
+  if v_invite.id is null then
+    raise exception 'Invite code not found';
+  end if;
+
+  if not v_invite.is_active then
+    raise exception 'Invite code is inactive';
+  end if;
+
+  if v_invite.expires_at is not null and v_invite.expires_at < now() then
+    raise exception 'Invite code has expired';
+  end if;
+
+  if v_invite.max_redemptions is not null and v_invite.redeemed_count >= v_invite.max_redemptions then
+    raise exception 'Invite code has reached its redemption limit';
+  end if;
+
+  if v_invite.membership_plan_id is not null and not exists (
+    select 1
+    from public.gym_membership_plans gmp
+    where gmp.id = v_invite.membership_plan_id
+      and gmp.gym_id = v_invite.gym_id
+      and gmp.is_active = true
+  ) then
+    raise exception 'Invite code membership plan is no longer available';
+  end if;
+
+  insert into public.gym_memberships(
+    gym_id,
+    user_id,
+    role,
+    membership_status,
+    membership_plan_id,
+    started_at
+  )
+  values (
+    v_invite.gym_id,
+    v_user_id,
+    v_invite.role,
+    v_invite.membership_status,
+    v_invite.membership_plan_id,
+    case when v_invite.membership_status in ('active', 'trial') then now() else null end
+  )
+  on conflict (gym_id, user_id) do update
+    set role = excluded.role,
+        membership_status = case
+          when public.gym_memberships.membership_status in ('active', 'trial') then public.gym_memberships.membership_status
+          else excluded.membership_status
+        end,
+        membership_plan_id = coalesce(excluded.membership_plan_id, public.gym_memberships.membership_plan_id),
+        started_at = coalesce(public.gym_memberships.started_at, excluded.started_at)
+  returning id
+  into v_membership_id;
+
+  insert into public.gym_invite_code_redemptions(
+    invite_code_id,
+    gym_id,
+    user_id,
+    membership_id
+  )
+  values (
+    v_invite.id,
+    v_invite.gym_id,
+    v_user_id,
+    v_membership_id
+  )
+  on conflict (invite_code_id, user_id) do nothing
+  returning id
+  into v_redemption_id;
+
+  if v_redemption_id is not null then
+    update public.gym_invite_codes
+    set redeemed_count = redeemed_count + 1
+    where id = v_invite.id;
+  else
+    return v_membership_id;
+  end if;
+
+  v_request_status := case
+    when v_invite.membership_status in ('active', 'trial') then 'approved'
+    else 'pending'
+  end;
+
+  if v_request_status = 'approved' then
+    update public.gym_join_requests
+    set status = 'cancelled',
+        staff_note = coalesce(staff_note, 'Superseded by invite code redemption')
+    where gym_id = v_invite.gym_id
+      and user_id = v_user_id
+      and status = 'pending';
+  end if;
+
+  if v_request_status = 'pending' then
+    update public.gym_join_requests gjr
+    set requested_membership_plan_id = v_invite.membership_plan_id,
+        source = 'invite_code',
+        invite_code_id = v_invite.id,
+        note = nullif(trim(coalesce(p_note, '')), '')
+    where gjr.gym_id = v_invite.gym_id
+      and gjr.user_id = v_user_id
+      and gjr.status = 'pending'
+    returning id
+    into v_existing_request_id;
+
+    if v_existing_request_id is not null then
+      return v_membership_id;
+    end if;
+  end if;
+
+  insert into public.gym_join_requests(
+    gym_id,
+    user_id,
+    requested_membership_plan_id,
+    source,
+    invite_code_id,
+    status,
+    note,
+    reviewed_by,
+    reviewed_at
+  )
+  values (
+    v_invite.gym_id,
+    v_user_id,
+    v_invite.membership_plan_id,
+    'invite_code',
+    v_invite.id,
+    v_request_status,
+    nullif(trim(coalesce(p_note, '')), ''),
+    case when v_request_status = 'approved' then v_invite.created_by else null end,
+    case when v_request_status = 'approved' then now() else null end
+  );
+
+  return v_membership_id;
+end;
+$$;
+
+create or replace function public.review_gym_join_request(
+  p_request_id uuid,
+  p_next_status text,
+  p_staff_note text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_request public.gym_join_requests%rowtype;
+  v_membership_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if p_next_status not in ('approved', 'rejected', 'cancelled') then
+    raise exception 'Invalid join request status';
+  end if;
+
+  select *
+  into v_request
+  from public.gym_join_requests gjr
+  where gjr.id = p_request_id
+  for update;
+
+  if v_request.id is null then
+    raise exception 'Join request not found';
+  end if;
+
+  if not public.is_gym_staff(v_request.gym_id, v_user_id) then
+    raise exception 'Gym staff access is required';
+  end if;
+
+  insert into public.gym_memberships(
+    gym_id,
+    user_id,
+    role,
+    membership_status,
+    membership_plan_id,
+    started_at
+  )
+  values (
+    v_request.gym_id,
+    v_request.user_id,
+    'member',
+    case when p_next_status = 'approved' then 'active'::public.membership_status else 'cancelled'::public.membership_status end,
+    v_request.requested_membership_plan_id,
+    case when p_next_status = 'approved' then now() else null end
+  )
+  on conflict (gym_id, user_id) do update
+    set membership_status = case
+          when p_next_status = 'approved' then 'active'::public.membership_status
+          when public.gym_memberships.membership_status = 'pending' then 'cancelled'::public.membership_status
+          else public.gym_memberships.membership_status
+        end,
+        membership_plan_id = coalesce(v_request.requested_membership_plan_id, public.gym_memberships.membership_plan_id),
+        started_at = case
+          when p_next_status = 'approved' then coalesce(public.gym_memberships.started_at, now())
+          else public.gym_memberships.started_at
+        end
+  returning id
+  into v_membership_id;
+
+  update public.gym_join_requests
+  set status = p_next_status,
+      staff_note = nullif(trim(coalesce(p_staff_note, '')), ''),
+      reviewed_by = v_user_id,
+      reviewed_at = now()
+  where id = p_request_id;
+
+  return v_membership_id;
+end;
+$$;
+
+revoke all on function public.request_gym_membership(uuid, uuid, text) from public;
+grant execute on function public.request_gym_membership(uuid, uuid, text) to authenticated;
+
+revoke all on function public.redeem_gym_invite_code(text, text) from public;
+grant execute on function public.redeem_gym_invite_code(text, text) to authenticated;
+
+revoke all on function public.review_gym_join_request(uuid, text, text) from public;
+grant execute on function public.review_gym_join_request(uuid, text, text) to authenticated;
+
+alter table public.gym_invite_codes enable row level security;
+alter table public.gym_join_requests enable row level security;
+alter table public.gym_invite_code_redemptions enable row level security;
+
+drop policy if exists gym_invite_codes_staff_all on public.gym_invite_codes;
+create policy gym_invite_codes_staff_all
+on public.gym_invite_codes for all to authenticated
+using (public.is_gym_staff(gym_id, auth.uid()))
+with check (public.is_gym_staff(gym_id, auth.uid()));
+
+drop policy if exists gym_join_requests_select_self_or_staff on public.gym_join_requests;
+create policy gym_join_requests_select_self_or_staff
+on public.gym_join_requests for select to authenticated
+using (user_id = auth.uid() or public.is_gym_staff(gym_id, auth.uid()));
+
+drop policy if exists gym_join_requests_insert_self on public.gym_join_requests;
+create policy gym_join_requests_insert_self
+on public.gym_join_requests for insert to authenticated
+with check (user_id = auth.uid());
+
+drop policy if exists gym_join_requests_update_self_cancel_or_staff on public.gym_join_requests;
+create policy gym_join_requests_update_self_cancel_or_staff
+on public.gym_join_requests for update to authenticated
+using (public.is_gym_staff(gym_id, auth.uid()) or (user_id = auth.uid() and status = 'pending'))
+with check (public.is_gym_staff(gym_id, auth.uid()) or (user_id = auth.uid() and status = 'cancelled'));
+
+drop policy if exists gym_invite_redemptions_select_self_or_staff on public.gym_invite_code_redemptions;
+create policy gym_invite_redemptions_select_self_or_staff
+on public.gym_invite_code_redemptions for select to authenticated
+using (user_id = auth.uid() or public.is_gym_staff(gym_id, auth.uid()));

--- a/packages/db/supabase/migrations/202605130001_join_request_subscription_activation.sql
+++ b/packages/db/supabase/migrations/202605130001_join_request_subscription_activation.sql
@@ -1,0 +1,224 @@
+-- Create manual subscription and invoice records when staff approve a plan-backed join request.
+
+create or replace function public.review_gym_join_request(
+  p_request_id uuid,
+  p_next_status text,
+  p_staff_note text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_request public.gym_join_requests%rowtype;
+  v_plan public.gym_membership_plans%rowtype;
+  v_membership_id uuid;
+  v_subscription_id uuid;
+  v_invoice_id uuid;
+  v_subscription_status public.subscription_status;
+  v_period_end timestamptz;
+  v_trial_ends_at timestamptz;
+begin
+  if v_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if p_next_status not in ('approved', 'rejected', 'cancelled') then
+    raise exception 'Invalid join request status';
+  end if;
+
+  select *
+  into v_request
+  from public.gym_join_requests gjr
+  where gjr.id = p_request_id
+  for update;
+
+  if v_request.id is null then
+    raise exception 'Join request not found';
+  end if;
+
+  if not public.is_gym_staff(v_request.gym_id, v_user_id) then
+    raise exception 'Gym staff access is required';
+  end if;
+
+  insert into public.gym_memberships(
+    gym_id,
+    user_id,
+    role,
+    membership_status,
+    membership_plan_id,
+    started_at
+  )
+  values (
+    v_request.gym_id,
+    v_request.user_id,
+    'member',
+    case when p_next_status = 'approved' then 'active'::public.membership_status else 'cancelled'::public.membership_status end,
+    v_request.requested_membership_plan_id,
+    case when p_next_status = 'approved' then now() else null end
+  )
+  on conflict (gym_id, user_id) do update
+    set membership_status = case
+          when p_next_status = 'approved' then 'active'::public.membership_status
+          when public.gym_memberships.membership_status = 'pending' then 'cancelled'::public.membership_status
+          else public.gym_memberships.membership_status
+        end,
+        membership_plan_id = coalesce(v_request.requested_membership_plan_id, public.gym_memberships.membership_plan_id),
+        started_at = case
+          when p_next_status = 'approved' then coalesce(public.gym_memberships.started_at, now())
+          else public.gym_memberships.started_at
+        end
+  returning id
+  into v_membership_id;
+
+  if p_next_status = 'approved' and v_request.requested_membership_plan_id is not null then
+    select *
+    into v_plan
+    from public.gym_membership_plans gmp
+    where gmp.id = v_request.requested_membership_plan_id
+      and gmp.gym_id = v_request.gym_id
+      and gmp.is_active = true;
+
+    if v_plan.id is null then
+      raise exception 'Requested membership plan is no longer available';
+    end if;
+
+    v_trial_ends_at := case
+      when coalesce(v_plan.trial_days, 0) > 0 then now() + make_interval(days => v_plan.trial_days)
+      else null
+    end;
+
+    v_subscription_status := case
+      when v_trial_ends_at is not null then 'trialing'::public.subscription_status
+      else 'active'::public.subscription_status
+    end;
+
+    v_period_end := case v_plan.billing_cycle
+      when 'monthly' then now() + interval '1 month'
+      when 'quarterly' then now() + interval '3 months'
+      when 'yearly' then now() + interval '1 year'
+      when 'dropin' then null
+      else null
+    end;
+
+    select ms.id
+    into v_subscription_id
+    from public.member_subscriptions ms
+    where ms.gym_id = v_request.gym_id
+      and ms.user_id = v_request.user_id
+      and ms.membership_plan_id = v_plan.id
+      and ms.status <> 'canceled'
+    order by ms.created_at desc
+    limit 1
+    for update;
+
+    if v_subscription_id is null then
+      insert into public.member_subscriptions(
+        gym_id,
+        user_id,
+        membership_plan_id,
+        status,
+        provider,
+        current_period_start,
+        current_period_end,
+        trial_ends_at,
+        metadata
+      )
+      values (
+        v_request.gym_id,
+        v_request.user_id,
+        v_plan.id,
+        v_subscription_status,
+        'manual',
+        now(),
+        v_period_end,
+        v_trial_ends_at,
+        jsonb_build_object(
+          'source', 'join_request_approval',
+          'join_request_id', v_request.id,
+          'approved_by', v_user_id,
+          'billing_cycle', v_plan.billing_cycle
+        )
+      )
+      returning id
+      into v_subscription_id;
+    else
+      update public.member_subscriptions
+      set status = v_subscription_status,
+          provider = 'manual',
+          current_period_start = coalesce(current_period_start, now()),
+          current_period_end = coalesce(current_period_end, v_period_end),
+          trial_ends_at = v_trial_ends_at,
+          canceled_at = null,
+          cancel_at = null,
+          metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+            'source', 'join_request_approval',
+            'join_request_id', v_request.id,
+            'approved_by', v_user_id,
+            'billing_cycle', v_plan.billing_cycle
+          )
+      where id = v_subscription_id;
+    end if;
+
+    if v_plan.price_cents > 0 then
+      select i.id
+      into v_invoice_id
+      from public.invoices i
+      where i.subscription_id = v_subscription_id
+        and i.metadata->>'join_request_id' = v_request.id::text
+      order by i.created_at desc
+      limit 1;
+
+      if v_invoice_id is null then
+        insert into public.invoices(
+          subscription_id,
+          gym_id,
+          user_id,
+          status,
+          currency,
+          subtotal_cents,
+          tax_cents,
+          total_cents,
+          amount_paid_cents,
+          amount_due_cents,
+          due_at,
+          metadata
+        )
+        values (
+          v_subscription_id,
+          v_request.gym_id,
+          v_request.user_id,
+          'open',
+          v_plan.currency,
+          v_plan.price_cents,
+          0,
+          v_plan.price_cents,
+          0,
+          v_plan.price_cents,
+          coalesce(v_trial_ends_at, now() + interval '7 days'),
+          jsonb_build_object(
+            'source', 'join_request_approval',
+            'join_request_id', v_request.id,
+            'membership_plan_id', v_plan.id,
+            'manual_collection', true
+          )
+        );
+      end if;
+    end if;
+  end if;
+
+  update public.gym_join_requests
+  set status = p_next_status,
+      staff_note = nullif(trim(coalesce(p_staff_note, '')), ''),
+      reviewed_by = v_user_id,
+      reviewed_at = now()
+  where id = p_request_id;
+
+  return v_membership_id;
+end;
+$$;
+
+revoke all on function public.review_gym_join_request(uuid, text, text) from public;
+grant execute on function public.review_gym_join_request(uuid, text, text) to authenticated;

--- a/packages/db/supabase/migrations/202605130002_manual_invoice_payments.sql
+++ b/packages/db/supabase/migrations/202605130002_manual_invoice_payments.sql
@@ -1,0 +1,105 @@
+-- Record manual member invoice payments with an auditable transaction row.
+
+create or replace function public.record_manual_invoice_payment(
+  p_invoice_id uuid,
+  p_amount_cents integer default null,
+  p_payment_method_type text default 'manual',
+  p_reference text default null,
+  p_note text default null,
+  p_captured_at timestamptz default now()
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_invoice public.invoices%rowtype;
+  v_amount_cents integer;
+  v_new_amount_paid integer;
+  v_new_amount_due integer;
+  v_payment_id uuid;
+begin
+  if v_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select *
+  into v_invoice
+  from public.invoices i
+  where i.id = p_invoice_id
+  for update;
+
+  if v_invoice.id is null then
+    raise exception 'Invoice not found';
+  end if;
+
+  if not public.is_gym_staff(v_invoice.gym_id, v_user_id) then
+    raise exception 'Gym staff access is required';
+  end if;
+
+  v_amount_cents := coalesce(p_amount_cents, nullif(v_invoice.amount_due_cents, 0), v_invoice.total_cents);
+
+  if v_amount_cents is null or v_amount_cents <= 0 then
+    raise exception 'Payment amount must be greater than zero';
+  end if;
+
+  insert into public.payment_transactions(
+    invoice_id,
+    subscription_id,
+    gym_id,
+    user_id,
+    provider,
+    status,
+    payment_method_type,
+    amount_cents,
+    fee_cents,
+    tax_cents,
+    currency,
+    captured_at,
+    metadata
+  )
+  values (
+    v_invoice.id,
+    v_invoice.subscription_id,
+    v_invoice.gym_id,
+    v_invoice.user_id,
+    'manual',
+    'paid',
+    nullif(trim(coalesce(p_payment_method_type, 'manual')), ''),
+    v_amount_cents,
+    0,
+    0,
+    v_invoice.currency,
+    coalesce(p_captured_at, now()),
+    jsonb_build_object(
+      'source', 'manual_invoice_payment',
+      'reference', nullif(trim(coalesce(p_reference, '')), ''),
+      'note', nullif(trim(coalesce(p_note, '')), ''),
+      'recorded_by', v_user_id
+    )
+  )
+  returning id
+  into v_payment_id;
+
+  v_new_amount_paid := v_invoice.amount_paid_cents + v_amount_cents;
+  v_new_amount_due := greatest(v_invoice.total_cents - v_new_amount_paid, 0);
+
+  update public.invoices
+  set amount_paid_cents = v_new_amount_paid,
+      amount_due_cents = v_new_amount_due,
+      status = case when v_new_amount_due = 0 then 'paid'::public.payment_status else 'open'::public.payment_status end,
+      paid_at = case when v_new_amount_due = 0 then coalesce(p_captured_at, now()) else paid_at end,
+      metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+        'last_manual_payment_id', v_payment_id,
+        'last_manual_payment_at', coalesce(p_captured_at, now())
+      )
+  where id = v_invoice.id;
+
+  return v_payment_id;
+end;
+$$;
+
+revoke all on function public.record_manual_invoice_payment(uuid, integer, text, text, text, timestamptz) from public;
+grant execute on function public.record_manual_invoice_payment(uuid, integer, text, text, text, timestamptz) to authenticated;

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -38,6 +38,7 @@ import type {
   LeaderboardTimeframe,
   ReportTargetType,
   StaffShiftStatus,
+  MemberWorkoutPlanStatus,
   SupportAccessGrantStatus,
   SupportAccessSessionStatus,
   StaffTimeEntryStatus,
@@ -48,6 +49,7 @@ import type {
   WorkoutType,
   WorkoutVisibility,
   GymRole,
+  GymJoinRequestStatus,
   MembershipStatus,
   IncidentNotificationChannel,
   IncidentSeverity,
@@ -164,6 +166,38 @@ export interface UpdateMembershipInput {
   membershipId: string;
   membershipStatus?: MembershipStatus;
   role?: GymRole;
+}
+
+export interface RequestGymMembershipInput {
+  gymId: string;
+  membershipPlanId?: string | null;
+  note?: string | null;
+}
+
+export interface RedeemGymInviteCodeInput {
+  code: string;
+  note?: string | null;
+}
+
+export interface CreateGymInviteCodeInput {
+  code?: string;
+  label?: string | null;
+  role?: GymRole;
+  membershipStatus?: MembershipStatus;
+  membershipPlanId?: string | null;
+  maxRedemptions?: number | null;
+  expiresAt?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpdateGymInviteCodeInput extends Partial<CreateGymInviteCodeInput> {
+  isActive?: boolean;
+}
+
+export interface ReviewGymJoinRequestInput {
+  requestId: string;
+  nextStatus: Exclude<GymJoinRequestStatus, "pending">;
+  staffNote?: string | null;
 }
 
 export interface UpsertGymRolePermissionInput {
@@ -381,6 +415,19 @@ export interface CreateStaffShiftInput {
 }
 
 export interface UpdateStaffShiftInput extends Partial<CreateStaffShiftInput> {}
+
+export interface CreateMemberWorkoutPlanInput {
+  memberUserId: string;
+  coachUserId?: string | null;
+  title: string;
+  goal?: string | null;
+  status?: MemberWorkoutPlanStatus;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  planJson?: Record<string, unknown>;
+}
+
+export interface UpdateMemberWorkoutPlanInput extends Partial<CreateMemberWorkoutPlanInput> {}
 
 export interface CreateStaffTimeEntryInput {
   shiftId?: string | null;

--- a/packages/types/src/domain.ts
+++ b/packages/types/src/domain.ts
@@ -121,6 +121,10 @@ export type MembershipStatus =
   | "paused"
   | "cancelled";
 
+export type GymJoinRequestStatus = "pending" | "approved" | "rejected" | "cancelled";
+
+export type GymJoinRequestSource = "public_request" | "invite_code" | "staff_created";
+
 export type StaffShiftStatus =
   | "scheduled"
   | "confirmed"
@@ -320,11 +324,46 @@ export interface GymMembership {
   id: string;
   gymId: string;
   userId: string;
+  coachUserId?: string | null;
   role: GymRole;
   membershipStatus: MembershipStatus;
   membershipPlanId?: string | null;
   startedAt?: string | null;
   endsAt?: string | null;
+}
+
+export interface GymInviteCode {
+  id: string;
+  gymId: string;
+  code: string;
+  label?: string | null;
+  role: GymRole;
+  membershipStatus: MembershipStatus;
+  membershipPlanId?: string | null;
+  maxRedemptions?: number | null;
+  redeemedCount: number;
+  expiresAt?: string | null;
+  isActive: boolean;
+  createdBy?: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GymJoinRequest {
+  id: string;
+  gymId: string;
+  userId: string;
+  requestedMembershipPlanId?: string | null;
+  source: GymJoinRequestSource;
+  inviteCodeId?: string | null;
+  status: GymJoinRequestStatus;
+  note?: string | null;
+  staffNote?: string | null;
+  reviewedBy?: string | null;
+  reviewedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface GymPermissionCatalogEntry {
@@ -1762,6 +1801,24 @@ export interface DunningEvent {
   result?: string | null;
   note?: string | null;
   metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type MemberWorkoutPlanStatus = "draft" | "active" | "paused" | "completed" | "archived";
+
+export interface MemberWorkoutPlan {
+  id: string;
+  gymId: string;
+  memberUserId: string;
+  coachUserId?: string | null;
+  title: string;
+  goal?: string | null;
+  status: MemberWorkoutPlanStatus;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  planJson: Record<string, unknown>;
+  createdBy?: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/ui/src/primitives/Avatar.tsx
+++ b/packages/ui/src/primitives/Avatar.tsx
@@ -13,10 +13,14 @@ export interface AvatarProps {
   theme: KruxtTheme;
   /** Size preset */
   size?: AvatarSize;
-  /** Image URI – when absent, initials are rendered */
+  /** Image URI; when absent, initials are rendered */
   imageUri?: string;
+  /** Compatibility alias for imageUri */
+  uri?: string | null;
   /** Initials (1-2 chars) shown when no image */
   initials?: string;
+  /** Display name used to derive initials */
+  name?: string;
   /** Show an online indicator dot */
   online?: boolean;
   /** Show accent ring (rank / achievement highlight) */
@@ -60,7 +64,9 @@ export function Avatar({
   theme,
   size = "md",
   imageUri,
+  uri,
   initials,
+  name,
   online,
   ring = false,
   style,
@@ -69,6 +75,15 @@ export function Avatar({
   const dim = SIZE_MAP[size];
   const half = dim / 2;
   const dotDim = DOT_SIZE_MAP[size];
+  const resolvedImageUri = imageUri ?? uri ?? undefined;
+  const resolvedInitials =
+    initials ??
+    name
+      ?.split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0])
+      .join("");
 
   const containerStyle: ViewStyle = {
     width: dim,
@@ -87,11 +102,11 @@ export function Avatar({
     <View
       style={[containerStyle, style]}
       accessibilityRole="image"
-      accessibilityLabel={accessibilityLabel ?? initials ?? "Avatar"}
+      accessibilityLabel={accessibilityLabel ?? name ?? resolvedInitials ?? "Avatar"}
     >
-      {imageUri ? (
+      {resolvedImageUri ? (
         <Image
-          source={{ uri: imageUri }}
+          source={{ uri: resolvedImageUri }}
           style={{ width: dim, height: dim, borderRadius: half }}
           resizeMode="cover"
         />
@@ -107,7 +122,7 @@ export function Avatar({
           ]}
           numberOfLines={1}
         >
-          {initials?.toUpperCase() ?? "?"}
+          {resolvedInitials?.toUpperCase() ?? "?"}
         </Text>
       )}
 

--- a/packages/ui/src/primitives/Badge.tsx
+++ b/packages/ui/src/primitives/Badge.tsx
@@ -6,7 +6,8 @@ import type { KruxtTheme } from "../theme";
 // Types
 // ---------------------------------------------------------------------------
 
-export type BadgeVariant = "default" | "accent" | "success" | "warning" | "danger";
+export type BadgeVariant = "default" | "accent" | "success" | "warning" | "danger" | "info" | "muted";
+export type BadgeSize = "sm" | "md" | "lg";
 
 export interface BadgeProps {
   /** Theme object */
@@ -17,6 +18,8 @@ export interface BadgeProps {
   label: string;
   /** Optional icon element rendered before the label */
   icon?: React.ReactNode;
+  /** Size preset */
+  size?: BadgeSize | string;
   /** Override container style */
   style?: ViewStyle;
 }
@@ -25,9 +28,10 @@ export interface BadgeProps {
 // Component
 // ---------------------------------------------------------------------------
 
-export function Badge({ theme, variant = "default", label, icon, style }: BadgeProps) {
+export function Badge({ theme, variant = "default", label, icon, size = "md", style }: BadgeProps) {
   const bg = getBadgeBg(variant, theme);
   const fg = getBadgeFg(variant, theme);
+  const small = size === "sm";
 
   return (
     <View
@@ -36,8 +40,8 @@ export function Badge({ theme, variant = "default", label, icon, style }: BadgeP
         {
           backgroundColor: bg,
           borderRadius: theme.radii.badge,
-          paddingHorizontal: theme.spacing.md,
-          paddingVertical: theme.spacing.xs,
+          paddingHorizontal: small ? theme.spacing.sm : theme.spacing.md,
+          paddingVertical: small ? 2 : theme.spacing.xs,
         },
         style,
       ]}
@@ -46,7 +50,7 @@ export function Badge({ theme, variant = "default", label, icon, style }: BadgeP
     >
       {icon && <View style={styles.icon}>{icon}</View>}
       <Text
-        style={[styles.label, { color: fg, fontFamily: theme.typography.body }]}
+        style={[styles.label, small && styles.labelSmall, { color: fg, fontFamily: theme.typography.body }]}
         numberOfLines={1}
       >
         {label}
@@ -65,6 +69,10 @@ function getBadgeBg(variant: BadgeVariant, theme: KruxtTheme): string {
       return `${theme.colors.steel}33`;
     case "accent":
       return `${theme.colors.accentPrimary}26`;
+    case "info":
+      return `${theme.colors.accentPrimary}1F`;
+    case "muted":
+      return `${theme.colors.steel}1A`;
     case "success":
       return `${theme.colors.success}26`;
     case "warning":
@@ -80,6 +88,10 @@ function getBadgeFg(variant: BadgeVariant, theme: KruxtTheme): string {
       return theme.colors.steel;
     case "accent":
       return theme.colors.accentPrimary;
+    case "info":
+      return theme.colors.accentPrimary;
+    case "muted":
+      return theme.colors.textSecondary;
     case "success":
       return theme.colors.success;
     case "warning":
@@ -105,5 +117,8 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 12,
     fontWeight: "600",
+  } as TextStyle,
+  labelSmall: {
+    fontSize: 10,
   } as TextStyle,
 });

--- a/packages/ui/src/primitives/Chip.tsx
+++ b/packages/ui/src/primitives/Chip.tsx
@@ -24,6 +24,8 @@ export interface ChipProps {
   onPress?: () => void;
   /** Show a close "x" button */
   closeable?: boolean;
+  /** Size preset */
+  size?: "sm" | "md" | "lg" | string;
   /** Close handler (only relevant when closeable) */
   onClose?: () => void;
   /** Override container style */
@@ -41,6 +43,7 @@ export function Chip({
   onPress,
   closeable = false,
   onClose,
+  size = "md",
   style,
 }: ChipProps) {
   const bg = selected ? `${theme.colors.accentPrimary}26` : `${theme.colors.steel}1A`;
@@ -55,6 +58,7 @@ export function Chip({
       accessibilityState={{ selected }}
       style={({ pressed }) => [
         styles.container,
+        size === "sm" && styles.containerSmall,
         {
           backgroundColor: bg,
           borderColor: border,
@@ -67,6 +71,7 @@ export function Chip({
       <Text
         style={[
           styles.label,
+          size === "sm" && styles.labelSmall,
           { color: fg, fontFamily: theme.typography.body },
         ]}
         numberOfLines={1}
@@ -101,9 +106,16 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     alignSelf: "flex-start",
   } as ViewStyle,
+  containerSmall: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  } as ViewStyle,
   label: {
     fontSize: 13,
     fontWeight: "500",
+  } as TextStyle,
+  labelSmall: {
+    fontSize: 11,
   } as TextStyle,
   close: {
     fontSize: 11,

--- a/packages/ui/src/primitives/EmptyState.tsx
+++ b/packages/ui/src/primitives/EmptyState.tsx
@@ -18,6 +18,8 @@ export interface EmptyStateProps {
   message?: string;
   /** Optional CTA button label */
   ctaLabel?: string;
+  /** Compatibility alias for ctaLabel */
+  actionLabel?: string;
   /** CTA press handler */
   onCtaPress?: () => void;
   /** Override container style */
@@ -34,6 +36,7 @@ export function EmptyState({
   title,
   message,
   ctaLabel,
+  actionLabel,
   onCtaPress,
   style,
 }: EmptyStateProps) {
@@ -65,10 +68,10 @@ export function EmptyState({
         </Text>
       )}
 
-      {ctaLabel && onCtaPress && (
+      {(ctaLabel ?? actionLabel) && onCtaPress && (
         <Button
           theme={theme}
-          label={ctaLabel}
+          label={ctaLabel ?? actionLabel ?? ""}
           onPress={onCtaPress}
           variant="primary"
           size="md"

--- a/packages/ui/src/primitives/ErrorState.tsx
+++ b/packages/ui/src/primitives/ErrorState.tsx
@@ -12,6 +12,8 @@ export interface ErrorStateProps {
   theme: KruxtTheme;
   /** Error icon element */
   icon?: React.ReactNode;
+  /** Error title */
+  title?: string;
   /** Error message */
   message: string;
   /** Retry button handler */
@@ -29,6 +31,7 @@ export interface ErrorStateProps {
 export function ErrorState({
   theme,
   icon,
+  title = "Something went wrong",
   message,
   onRetry,
   retryLabel = "Retry",
@@ -48,7 +51,7 @@ export function ErrorState({
           { color: theme.colors.danger, fontFamily: theme.typography.headline },
         ]}
       >
-        Something went wrong
+        {title}
       </Text>
 
       <Text

--- a/packages/ui/src/primitives/ListRow.tsx
+++ b/packages/ui/src/primitives/ListRow.tsx
@@ -18,14 +18,22 @@ export interface ListRowProps {
   /** Theme object */
   theme: KruxtTheme;
   /** Title text */
-  title: string;
+  title?: string;
+  /** Compatibility alias for title */
+  label?: string;
   /** Optional subtitle */
   subtitle?: string;
+  /** Compact trailing value */
+  value?: string;
+  /** Show a chevron when there is no custom trailing element */
+  chevron?: boolean;
+  /** Override title/label text style */
+  labelStyle?: TextStyle;
   /** Leading icon / avatar element */
   leading?: React.ReactNode;
   /** Trailing element (chevron, toggle, badge, etc.) */
   trailing?: React.ReactNode;
-  /** Press handler – makes the row pressable */
+  /** Press handler; makes the row pressable */
   onPress?: (e: GestureResponderEvent) => void;
   /** Show bottom divider */
   divider?: boolean;
@@ -42,24 +50,43 @@ export interface ListRowProps {
 export function ListRow({
   theme,
   title,
+  label,
   subtitle,
+  value,
+  chevron = false,
   leading,
   trailing,
   onPress,
   divider = false,
   style,
+  labelStyle,
   accessibilityLabel,
 }: ListRowProps) {
+  const resolvedTitle = title ?? label ?? "";
+  const resolvedTrailing =
+    trailing ??
+    (value ? (
+      <Text style={[styles.value, { color: theme.colors.textSecondary, fontFamily: theme.typography.body }]}>
+        {value}
+      </Text>
+    ) : chevron ? (
+      <Text style={[styles.chevron, { color: theme.colors.textSecondary }]}>{"\u203A"}</Text>
+    ) : null);
+
   const inner = (
     <>
       {leading && <View style={styles.leading}>{leading}</View>}
 
       <View style={styles.content}>
         <Text
-          style={[styles.title, { color: theme.colors.textPrimary, fontFamily: theme.typography.body }]}
+          style={[
+            styles.title,
+            { color: theme.colors.textPrimary, fontFamily: theme.typography.body },
+            labelStyle,
+          ]}
           numberOfLines={1}
         >
-          {title}
+          {resolvedTitle}
         </Text>
         {subtitle && (
           <Text
@@ -71,7 +98,7 @@ export function ListRow({
         )}
       </View>
 
-      {trailing && <View style={styles.trailing}>{trailing}</View>}
+      {resolvedTrailing && <View style={styles.trailing}>{resolvedTrailing}</View>}
     </>
   );
 
@@ -86,7 +113,7 @@ export function ListRow({
       <Pressable
         onPress={onPress}
         accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel ?? title}
+        accessibilityLabel={accessibilityLabel ?? resolvedTitle}
         style={({ pressed }) => [...containerStyles, pressed && styles.pressed]}
       >
         {inner}
@@ -95,7 +122,7 @@ export function ListRow({
   }
 
   return (
-    <View style={containerStyles} accessibilityLabel={accessibilityLabel ?? title}>
+    <View style={containerStyles} accessibilityLabel={accessibilityLabel ?? resolvedTitle}>
       {inner}
     </View>
   );
@@ -127,6 +154,14 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: 13,
     marginTop: 2,
+  } as TextStyle,
+  value: {
+    fontSize: 13,
+    fontWeight: "500",
+  } as TextStyle,
+  chevron: {
+    fontSize: 26,
+    lineHeight: 28,
   } as TextStyle,
   trailing: {
     marginLeft: 12,

--- a/packages/ui/src/primitives/Modal.tsx
+++ b/packages/ui/src/primitives/Modal.tsx
@@ -71,7 +71,7 @@ export function Modal({
             paddingBottom: bottomInset,
           },
         ]}
-        accessibilityRole="dialog"
+        accessibilityViewIsModal
         accessibilityLabel={title}
       >
         {/* Handle */}

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -38,7 +38,19 @@ export interface KruxtTheme {
 
 export const darkTheme: KruxtTheme = {
   mode: "dark",
-  colors: { ...kruxtTheme.colors },
+  colors: {
+    baseBackground: kruxtTheme.colors.base,
+    baseSurface: kruxtTheme.colors.surface,
+    basePanel: kruxtTheme.colors.panel,
+    textPrimary: kruxtTheme.colors.textPrimary,
+    textSecondary: kruxtTheme.colors.textSecondary,
+    accentPrimary: kruxtTheme.colors.ionBlue,
+    accentMuted: kruxtTheme.colors.ionBlueMuted,
+    success: kruxtTheme.colors.success,
+    warning: kruxtTheme.colors.warning,
+    danger: kruxtTheme.colors.danger,
+    steel: kruxtTheme.colors.steel,
+  },
   radii: { ...kruxtTheme.radii },
   typography: { ...kruxtTheme.typography },
   spacing: { ...kruxtTheme.spacing },

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -52,6 +52,9 @@ export const kruxtTheme = {
     md: 12,
     lg: 14,       // card default
     xl: 16,       // panel
+    button: 8,
+    badge: 999,
+    card: 14,
     pill: 999,    // badges / sigils
   },
 

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "declaration": true,
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Salvages the foundation layer from Codex's uncommitted local work so admin/web/mobile can build on it.

**Types** (`packages/types/`): GymInviteCode, GymJoinRequest, MemberWorkoutPlan, coachUserId on GymMembership, brand-settings shapes.

**DB migrations** (`packages/db/supabase/migrations/`):
- coaching + workout plans (coach_user_id, gym_member_workout_plans table)
- join requests + auto-activation RPC
- manual invoice payments RPC

**UI** (`packages/ui/`): dark + light theme tokens, primitive polish (Avatar/Badge/Chip/EmptyState/ErrorState/ListRow/Modal).

Foundation only — admin/web/mobile changes follow in subsequent PRs.

🤖 Codex's work salvaged & shipped by Claude