### PR TITLE
feat(admin): member directory, invite codes, coach, branding, staff, manual payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,13 @@ node_modules
 .env
 .env.*
 .next
+.turbo
 .expo
 .expo-shared
 dist
 build
 coverage
 supabase/.temp
+packages/db/supabase/migrations_archive/
 
 *.tsbuildinfo

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
+NEXT_PUBLIC_KRUXT_WEB_URL=http://localhost:3000

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -14,8 +14,10 @@
     "@kruxt/types": "workspace:*",
     "@kruxt/ui": "workspace:*",
     "@supabase/supabase-js": "^2.49.1",
+    "@types/qrcode": "^1.5.6",
     "clsx": "^2.1.1",
     "next": "^14.2.0",
+    "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.0"

--- a/apps/admin/src/app/(dashboard)/billing/page.tsx
+++ b/apps/admin/src/app/(dashboard)/billing/page.tsx
@@ -1,17 +1,104 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { PageHeader } from "@/components/page-header";
 import { StatCard } from "@/components/stat-card";
 import { DataTable, type Column } from "@/components/data-table";
 import { StatusBadge, statusToVariant } from "@/components/status-badge";
 import { ErrorBanner } from "@/components/error-banner";
 import { PageSkeleton } from "@/components/loading-skeleton";
+import { Modal } from "@/components/modal";
 import { useGym } from "@/contexts/gym-context";
 import { useServices } from "@/hooks/use-services";
 import { useAsync } from "@/hooks/use-async";
-import type { Invoice } from "@kruxt/types";
+import type { ManualBillingSettings, MemberSubscriptionDirectoryItem } from "@/services";
+import type { Invoice, PaymentTransaction } from "@kruxt/types";
 
-const columns: Column<Invoice>[] = [
+const INPUT =
+  "w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent/40";
+
+const emptyManualBillingDraft: ManualBillingSettings = {
+  instructions: "",
+  bankAccountLabel: "",
+  accountHolder: "",
+  iban: "",
+  paymentReferenceFormat: "",
+  cashDeskNote: "",
+  externalPaymentUrl: ""
+};
+
+function formatMoney(cents: number | null | undefined, currency = "USD"): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 2
+  }).format((cents ?? 0) / 100);
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return parsed.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+const subscriptionColumns: Column<MemberSubscriptionDirectoryItem>[] = [
+  {
+    key: "member",
+    header: "Member",
+    render: (row) => (
+      <div>
+        <p className="font-medium text-foreground">{row.profile?.label ?? row.userId.slice(0, 8)}</p>
+        <p className="text-xs text-muted-foreground font-kruxt-mono">{row.userId.slice(0, 8)}</p>
+      </div>
+    )
+  },
+  {
+    key: "plan",
+    header: "Plan",
+    render: (row) => (
+      <div>
+        <p className="font-medium text-foreground">{row.membershipPlan?.name ?? "No plan"}</p>
+        <p className="text-xs text-muted-foreground">
+          {row.membershipPlan
+            ? `${formatMoney(row.membershipPlan.priceCents, row.membershipPlan.currency)} / ${row.membershipPlan.billingCycle}`
+            : "Manual subscription"}
+        </p>
+      </div>
+    )
+  },
+  {
+    key: "status",
+    header: "Status",
+    render: (row) => <StatusBadge label={row.status} variant={statusToVariant(row.status)} dot />
+  },
+  {
+    key: "period",
+    header: "Period",
+    render: (row) => (
+      <div>
+        <p className="text-sm tabular-nums text-foreground font-kruxt-mono">
+          {formatDate(row.currentPeriodStart)} → {formatDate(row.currentPeriodEnd)}
+        </p>
+        {row.trialEndsAt ? <p className="text-xs text-muted-foreground">Trial until {formatDate(row.trialEndsAt)}</p> : null}
+      </div>
+    )
+  },
+  {
+    key: "provider",
+    header: "Provider",
+    render: (row) => (
+      <span className="text-sm text-muted-foreground">
+        {row.provider}
+        {row.paymentMethodBrand || row.paymentMethodLast4
+          ? ` / ${[row.paymentMethodBrand, row.paymentMethodLast4].filter(Boolean).join(" ")}`
+          : ""}
+      </span>
+    )
+  }
+];
+
+const baseInvoiceColumns: Column<Invoice>[] = [
   {
     key: "id",
     header: "Invoice",
@@ -31,7 +118,7 @@ const columns: Column<Invoice>[] = [
     sortable: true,
     render: (row) => (
       <span className="text-sm font-medium tabular-nums text-foreground font-kruxt-mono">
-        ${((row.totalCents ?? 0) / 100).toFixed(2)}
+        {formatMoney(row.totalCents, row.currency)}
       </span>
     ),
   },
@@ -67,51 +154,462 @@ const columns: Column<Invoice>[] = [
   },
 ];
 
+const paymentColumns: Column<PaymentTransaction>[] = [
+  {
+    key: "id",
+    header: "Payment",
+    render: (row) => (
+      <div>
+        <p className="font-medium text-foreground font-kruxt-mono">{row.id.slice(0, 8)}</p>
+        <p className="text-xs text-muted-foreground">{String(row.metadata?.reference ?? row.provider)}</p>
+      </div>
+    )
+  },
+  {
+    key: "amount",
+    header: "Amount",
+    render: (row) => (
+      <span className="text-sm font-medium tabular-nums text-foreground font-kruxt-mono">
+        {formatMoney(row.amountCents, row.currency)}
+      </span>
+    )
+  },
+  {
+    key: "method",
+    header: "Method",
+    render: (row) => <span className="text-sm text-muted-foreground">{row.paymentMethodType ?? row.provider}</span>
+  },
+  {
+    key: "status",
+    header: "Status",
+    render: (row) => <StatusBadge label={row.status} variant={statusToVariant(row.status)} dot />
+  },
+  {
+    key: "capturedAt",
+    header: "Captured",
+    render: (row) => (
+      <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">{formatDate(row.capturedAt)}</span>
+    )
+  }
+];
+
 export default function BillingPage() {
   const { gymId } = useGym();
   const { ops } = useServices();
+  const [invoiceActionId, setInvoiceActionId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [settingsMessage, setSettingsMessage] = useState<string | null>(null);
+  const [savingBillingSettings, setSavingBillingSettings] = useState(false);
+  const [billingDraft, setBillingDraft] = useState<ManualBillingSettings>(emptyManualBillingDraft);
+  const [paymentInvoice, setPaymentInvoice] = useState<Invoice | null>(null);
+  const [paymentForm, setPaymentForm] = useState({
+    amount: "",
+    paymentMethodType: "cash",
+    reference: "",
+    note: ""
+  });
 
   const invoices = useAsync(() => ops.listInvoices(gymId), [gymId]);
-  const subscriptions = useAsync(() => ops.listMemberSubscriptions(gymId), [gymId]);
+  const subscriptions = useAsync(() => ops.listMemberSubscriptionDirectory(gymId), [gymId]);
+  const payments = useAsync(() => ops.listPaymentTransactions(gymId), [gymId]);
+  const manualBilling = useAsync(() => ops.getManualBillingSettings(gymId), [gymId]);
 
-  if (invoices.status === "loading" || invoices.status === "idle") return <PageSkeleton />;
+  useEffect(() => {
+    if (manualBilling.status === "success") {
+      setBillingDraft(manualBilling.data ?? emptyManualBillingDraft);
+    }
+  }, [manualBilling.data, manualBilling.status]);
 
-  if (invoices.status === "error") {
+  function updateBillingDraft(key: keyof ManualBillingSettings, value: string) {
+    setBillingDraft((current) => ({ ...current, [key]: value }));
+    setSettingsMessage(null);
+  }
+
+  async function saveManualBillingSettings() {
+    setSavingBillingSettings(true);
+    setActionError(null);
+    setSettingsMessage(null);
+
+    try {
+      const settings = await ops.upsertManualBillingSettings(gymId, billingDraft);
+      setBillingDraft(settings);
+      setSettingsMessage("Payment instructions saved.");
+      manualBilling.refetch();
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unable to save payment instructions.");
+    } finally {
+      setSavingBillingSettings(false);
+    }
+  }
+
+  function openPaymentModal(invoice: Invoice) {
+    setPaymentInvoice(invoice);
+    setActionError(null);
+    setPaymentForm({
+      amount: ((invoice.amountDueCents || invoice.totalCents || 0) / 100).toFixed(2),
+      paymentMethodType: "cash",
+      reference: "",
+      note: ""
+    });
+  }
+
+  async function recordManualPayment() {
+    if (!paymentInvoice) return;
+
+    const normalizedAmount = Number(paymentForm.amount.replace(",", "."));
+    if (!Number.isFinite(normalizedAmount) || normalizedAmount <= 0) {
+      setActionError("Enter a payment amount greater than zero.");
+      return;
+    }
+
+    setInvoiceActionId(paymentInvoice.id);
+    setActionError(null);
+
+    try {
+      await ops.recordManualInvoicePayment(gymId, {
+        invoiceId: paymentInvoice.id,
+        amountCents: Math.round(normalizedAmount * 100),
+        paymentMethodType: paymentForm.paymentMethodType,
+        reference: paymentForm.reference,
+        note: paymentForm.note,
+        capturedAt: new Date().toISOString()
+      });
+      invoices.refetch();
+      payments.refetch();
+      subscriptions.refetch();
+      setPaymentInvoice(null);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Unable to record payment.");
+    } finally {
+      setInvoiceActionId(null);
+    }
+  }
+
+  if (
+    invoices.status === "loading" ||
+    invoices.status === "idle" ||
+    subscriptions.status === "loading" ||
+    subscriptions.status === "idle" ||
+    payments.status === "loading" ||
+    payments.status === "idle" ||
+    manualBilling.status === "loading" ||
+    manualBilling.status === "idle"
+  ) {
+    return <PageSkeleton />;
+  }
+
+  if (
+    invoices.status === "error" ||
+    subscriptions.status === "error" ||
+    payments.status === "error" ||
+    manualBilling.status === "error"
+  ) {
     return (
       <div className="space-y-6">
         <PageHeader title="Billing" description="Invoices, subscriptions, and payment management." />
-        <ErrorBanner message={invoices.error ?? "Unknown error"} onRetry={invoices.refetch} />
+        <ErrorBanner
+          message={invoices.error ?? subscriptions.error ?? payments.error ?? manualBilling.error ?? "Unknown error"}
+          onRetry={() => {
+            invoices.refetch();
+            subscriptions.refetch();
+            payments.refetch();
+            manualBilling.refetch();
+          }}
+        />
       </div>
     );
   }
 
   const invoiceList = invoices.data ?? [];
   const subList = subscriptions.data ?? [];
+  const paymentList = payments.data ?? [];
+  const invoiceColumns: Column<Invoice>[] = [
+    ...baseInvoiceColumns,
+    {
+      key: "actions",
+      header: "Actions",
+      render: (row) => (
+        row.status === "paid" ? (
+          <span className="text-xs text-muted-foreground">Paid {formatDate(row.paidAt)}</span>
+        ) : (
+          <button
+            type="button"
+            className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-kruxt-panel disabled:opacity-50"
+            onClick={() => openPaymentModal(row)}
+            disabled={invoiceActionId === row.id}
+          >
+            {invoiceActionId === row.id ? "Saving..." : "Record payment"}
+          </button>
+        )
+      )
+    }
+  ];
 
   const totalRevenue = invoiceList
     .filter((i) => i.status === "paid")
     .reduce((sum, i) => sum + (i.totalCents ?? 0), 0);
+  const collectedPayments = paymentList
+    .filter((payment) => payment.status === "paid")
+    .reduce((sum, payment) => sum + payment.amountCents, 0);
   const overdueCount = invoiceList.filter((i) => i.status === "open" && i.dueAt && new Date(i.dueAt) < new Date()).length;
-  const activeSubCount = subList.filter((s) => s.status === "active").length;
+  const activeSubCount = subList.filter((s) => s.status === "active" || s.status === "trialing").length;
+  const openInvoiceCount = invoiceList.filter((i) => i.status === "open").length;
 
   return (
     <div className="space-y-6">
       <PageHeader title="Billing" description="Invoices, subscriptions, and payment management." />
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <StatCard label="Revenue (Paid)" value={`$${(totalRevenue / 100).toLocaleString()}`} accent="success" />
+        <StatCard label="Revenue (Paid)" value={formatMoney(totalRevenue, invoiceList[0]?.currency ?? "USD")} accent="success" />
         <StatCard label="Active Subscriptions" value={activeSubCount} />
-        <StatCard label="Overdue Invoices" value={overdueCount} accent={overdueCount > 0 ? "danger" : "default"} />
-        <StatCard label="Total Invoices" value={invoiceList.length} />
+        <StatCard label="Manual Payments" value={formatMoney(collectedPayments, paymentList[0]?.currency ?? "USD")} />
+        <StatCard label="Open Invoices" value={openInvoiceCount} />
       </div>
+      {overdueCount > 0 && <ErrorBanner message={`${overdueCount} open invoices are overdue.`} />}
 
-      {invoiceList.length === 0 ? (
-        <div className="rounded-card border border-border bg-card p-8 text-center">
-          <p className="text-sm text-muted-foreground">No invoices yet.</p>
+      {actionError && <ErrorBanner message={actionError} onRetry={() => setActionError(null)} />}
+      {settingsMessage && (
+        <div className="rounded-card border border-kruxt-success/30 bg-kruxt-success/10 px-4 py-3 text-sm text-kruxt-success">
+          {settingsMessage}
         </div>
-      ) : (
-        <DataTable columns={columns} data={invoiceList} keyExtractor={(row) => row.id} searchable searchPlaceholder="Search invoices..." />
       )}
+
+      <section className="rounded-card border border-border bg-card p-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground font-kruxt-headline">Member Payment Instructions</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              These instructions appear beside open member invoices for manual collection.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded-button bg-kruxt-accent px-5 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+            onClick={() => void saveManualBillingSettings()}
+            disabled={savingBillingSettings}
+          >
+            {savingBillingSettings ? "Saving..." : "Save instructions"}
+          </button>
+        </div>
+
+        <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <div className="lg:col-span-2">
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="billing-instructions">
+              Instructions
+            </label>
+            <textarea
+              id="billing-instructions"
+              className={INPUT}
+              rows={3}
+              value={billingDraft.instructions}
+              onChange={(event) => updateBillingDraft("instructions", event.target.value)}
+              placeholder="Pay by bank transfer, POS at reception, or the payment link below. Your access is confirmed after staff records the payment."
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="billing-account-label">
+              Account label
+            </label>
+            <input
+              id="billing-account-label"
+              className={INPUT}
+              value={billingDraft.bankAccountLabel}
+              onChange={(event) => updateBillingDraft("bankAccountLabel", event.target.value)}
+              placeholder="BZone ASD membership account"
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="billing-holder">
+              Account holder
+            </label>
+            <input
+              id="billing-holder"
+              className={INPUT}
+              value={billingDraft.accountHolder}
+              onChange={(event) => updateBillingDraft("accountHolder", event.target.value)}
+              placeholder="BZone ASD"
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="billing-iban">
+              IBAN
+            </label>
+            <input
+              id="billing-iban"
+              className={`${INPUT} font-kruxt-mono`}
+              value={billingDraft.iban}
+              onChange={(event) => updateBillingDraft("iban", event.target.value)}
+              placeholder="IT00X0000000000000000000000"
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="billing-reference">
+              Reference format
+            </label>
+            <input
+              id="billing-reference"
+              className={INPUT}
+              value={billingDraft.paymentReferenceFormat}
+              onChange={(event) => updateBillingDraft("paymentReferenceFormat", event.target.value)}
+              placeholder="KRUXT {member name} {invoice id}"
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="billing-link">
+              External payment URL
+            </label>
+            <input
+              id="billing-link"
+              className={INPUT}
+              value={billingDraft.externalPaymentUrl}
+              onChange={(event) => updateBillingDraft("externalPaymentUrl", event.target.value)}
+              placeholder="https://..."
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground" htmlFor="billing-cash-note">
+              Reception note
+            </label>
+            <input
+              id="billing-cash-note"
+              className={INPUT}
+              value={billingDraft.cashDeskNote}
+              onChange={(event) => updateBillingDraft("cashDeskNote", event.target.value)}
+              placeholder="Cash and POS payments can be made at the front desk."
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground font-kruxt-headline">Member Subscriptions</h2>
+          <p className="text-sm text-muted-foreground">
+            Approved plan requests become manual subscriptions here until a payment provider is connected.
+          </p>
+        </div>
+        <DataTable
+          columns={subscriptionColumns}
+          data={subList}
+          keyExtractor={(row) => row.id}
+          searchable
+          searchPlaceholder="Search subscriptions..."
+          emptyMessage="No member subscriptions yet."
+        />
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground font-kruxt-headline">Invoices</h2>
+          <p className="text-sm text-muted-foreground">
+            Staff can record cash, bank transfer, POS, or external payment references while Stripe is still being connected.
+          </p>
+        </div>
+        {invoiceList.length === 0 ? (
+          <div className="rounded-card border border-border bg-card p-8 text-center">
+            <p className="text-sm text-muted-foreground">No invoices yet.</p>
+          </div>
+        ) : (
+          <DataTable columns={invoiceColumns} data={invoiceList} keyExtractor={(row) => row.id} searchable searchPlaceholder="Search invoices..." />
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground font-kruxt-headline">Payments</h2>
+          <p className="text-sm text-muted-foreground">
+            Manual payment records are kept as transactions so invoice changes have an audit trail.
+          </p>
+        </div>
+        <DataTable
+          columns={paymentColumns}
+          data={paymentList}
+          keyExtractor={(row) => row.id}
+          searchable
+          searchPlaceholder="Search payments..."
+          emptyMessage="No payments recorded yet."
+        />
+      </section>
+
+      <Modal
+        open={paymentInvoice !== null}
+        onClose={() => setPaymentInvoice(null)}
+        title="Record Manual Payment"
+        footer={
+          <>
+            <button
+              type="button"
+              className="rounded-md border border-border px-4 py-2 text-sm text-muted-foreground transition-colors hover:bg-kruxt-panel hover:text-foreground"
+              onClick={() => setPaymentInvoice(null)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rounded-md bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-60"
+              onClick={() => void recordManualPayment()}
+              disabled={!paymentInvoice || invoiceActionId === paymentInvoice.id}
+            >
+              {invoiceActionId === paymentInvoice?.id ? "Recording..." : "Record payment"}
+            </button>
+          </>
+        }
+      >
+        <div>
+          <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground" htmlFor="payment-amount">
+            Amount
+          </label>
+          <input
+            id="payment-amount"
+            className="w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-kruxt-accent/50"
+            value={paymentForm.amount}
+            onChange={(event) => setPaymentForm((form) => ({ ...form, amount: event.target.value }))}
+            inputMode="decimal"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground" htmlFor="payment-method">
+            Method
+          </label>
+          <select
+            id="payment-method"
+            className="w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-kruxt-accent/50"
+            value={paymentForm.paymentMethodType}
+            onChange={(event) => setPaymentForm((form) => ({ ...form, paymentMethodType: event.target.value }))}
+          >
+            <option value="cash">Cash</option>
+            <option value="bank_transfer">Bank transfer</option>
+            <option value="pos">POS</option>
+            <option value="stripe">Stripe</option>
+            <option value="manual">Manual</option>
+          </select>
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground" htmlFor="payment-reference">
+            Reference
+          </label>
+          <input
+            id="payment-reference"
+            className="w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-kruxt-accent/50"
+            value={paymentForm.reference}
+            onChange={(event) => setPaymentForm((form) => ({ ...form, reference: event.target.value }))}
+            placeholder="Receipt, bank CRO, POS id, or note"
+          />
+        </div>
+        <div>
+          <label className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground" htmlFor="payment-note">
+            Note
+          </label>
+          <textarea
+            id="payment-note"
+            className="min-h-24 w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-kruxt-accent/50"
+            value={paymentForm.note}
+            onChange={(event) => setPaymentForm((form) => ({ ...form, note: event.target.value }))}
+            placeholder="Optional internal note"
+          />
+        </div>
+        {actionError && <p className="rounded-md bg-kruxt-danger/10 px-3 py-2 text-sm text-kruxt-danger">{actionError}</p>}
+      </Modal>
     </div>
   );
 }

--- a/apps/admin/src/app/(dashboard)/layout.tsx
+++ b/apps/admin/src/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Sidebar } from "@/components/sidebar";
 import { TopBar } from "@/components/top-bar";
+import { GymOnboardingForm } from "@/components/gym-onboarding-form";
 import { useAuth } from "@/contexts/auth-context";
 import { useGym } from "@/contexts/gym-context";
 import { cn } from "@/lib/utils";
@@ -33,56 +34,13 @@ function FullPageLoader({ label }: { label?: string }) {
   );
 }
 
-function NoGymOnboarding({ onRefresh }: { onRefresh: () => void }) {
-  const { signOut, user } = useAuth();
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-kruxt-bg p-6">
-      <div className="w-full max-w-md rounded-card border border-border bg-card p-8">
-        <h1 className="text-xl font-bold text-foreground font-kruxt-headline">
-          No gym linked yet
-        </h1>
-        <p className="mt-3 text-sm text-muted-foreground">
-          Your account ({user?.email}) isn&apos;t linked to a gym yet. To get
-          started, create a gym row in Supabase and add yourself to{" "}
-          <code className="rounded bg-kruxt-panel px-1 py-0.5 text-xs">
-            gym_memberships
-          </code>{" "}
-          with role <code className="rounded bg-kruxt-panel px-1 py-0.5 text-xs">leader</code>{" "}
-          and status{" "}
-          <code className="rounded bg-kruxt-panel px-1 py-0.5 text-xs">active</code>.
-        </p>
-        <ol className="mt-4 list-inside list-decimal space-y-1 text-xs text-muted-foreground">
-          <li>Open Supabase → Table Editor → <code>gyms</code></li>
-          <li>Insert a new row (note the generated <code>id</code>)</li>
-          <li>Open <code>gym_memberships</code> and insert a row with <code>gym_id</code> = your new gym, <code>user_id</code> = {user?.id ?? "your auth user id"}, <code>role</code> = <code>leader</code>, <code>membership_status</code> = <code>active</code></li>
-          <li>Click Refresh below</li>
-        </ol>
-        <div className="mt-6 flex gap-3">
-          <button
-            onClick={onRefresh}
-            className="flex-1 rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90"
-          >
-            Refresh
-          </button>
-          <button
-            onClick={() => signOut()}
-            className="rounded-button border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-kruxt-panel"
-          >
-            Sign out
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const { user, loading: authLoading } = useAuth();
-  const { loading: gymLoading, noGymFound, refresh } = useGym();
+  const { loading: gymLoading, noGymFound } = useGym();
   const router = useRouter();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
@@ -109,7 +67,7 @@ export default function DashboardLayout({
 
   // 4) Auth'd but no gym linked
   if (noGymFound) {
-    return <NoGymOnboarding onRefresh={refresh} />;
+    return <GymOnboardingForm />;
   }
 
   // 5) All set — render the dashboard

--- a/apps/admin/src/app/(dashboard)/members/page.tsx
+++ b/apps/admin/src/app/(dashboard)/members/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import QRCode from "qrcode";
 import { PageHeader } from "@/components/page-header";
 import { StatCard } from "@/components/stat-card";
 import { DataTable, type Column } from "@/components/data-table";
@@ -12,7 +13,9 @@ import { Modal } from "@/components/modal";
 import { useGym } from "@/contexts/gym-context";
 import { useServices } from "@/hooks/use-services";
 import { useAsync } from "@/hooks/use-async";
-import type { GymMembership, MembershipStatus, GymRole } from "@kruxt/types";
+import type { GymJoinRequestDirectoryItem, GymMemberDirectoryItem, StaffProfileOption } from "@/services";
+import type { GymInviteCode } from "@kruxt/types";
+import type { GymRole, MembershipStatus } from "@kruxt/types";
 
 const INPUT =
   "w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent/40";
@@ -30,15 +33,82 @@ const statusFilters: { value: StatusFilter; label: string }[] = [
 
 interface AddMemberForm {
   userId: string;
+  profileQuery: string;
   role: GymRole;
   membershipStatus: MembershipStatus;
+  coachUserId: string;
 }
 
 const defaultAddForm: AddMemberForm = {
   userId: "",
+  profileQuery: "",
   role: "member",
   membershipStatus: "active",
+  coachUserId: "",
 };
+
+function memberLabel(member: GymMemberDirectoryItem): string {
+  return member.profile?.label ?? `${member.userId.slice(0, 8)}...`;
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return "-";
+  return new Date(value).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatDateTime(value?: string | null): string {
+  if (!value) return "Never";
+  return new Date(value).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function inviteUrl(code: string): string {
+  if (typeof window === "undefined") return `/join?code=${encodeURIComponent(code)}`;
+  const publicOrigin = process.env.NEXT_PUBLIC_KRUXT_WEB_URL || window.location.origin;
+  return `${publicOrigin.replace(/\/$/, "")}/join?code=${encodeURIComponent(code)}`;
+}
+
+function ProfileSearchResults({
+  options,
+  loading,
+  onSelect,
+}: {
+  options: StaffProfileOption[];
+  loading: boolean;
+  onSelect: (option: StaffProfileOption) => void;
+}) {
+  if (loading) {
+    return <p className="mt-2 text-xs text-muted-foreground">Searching profiles...</p>;
+  }
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 max-h-40 overflow-y-auto rounded-lg border border-border bg-card">
+      {options.map((option) => (
+        <button
+          key={option.userId}
+          type="button"
+          onClick={() => onSelect(option)}
+          className="block w-full border-b border-border px-3 py-2 text-left text-sm text-foreground transition-colors last:border-b-0 hover:bg-kruxt-panel"
+        >
+          <span className="font-medium">{option.displayName}</span>
+          {option.username && <span className="ml-2 text-xs text-muted-foreground">@{option.username}</span>}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 export default function MembersPage() {
   const { gymId } = useGym();
@@ -47,31 +117,134 @@ export default function MembersPage() {
   const [search, setSearch] = useState("");
   const [showAdd, setShowAdd] = useState(false);
   const [addForm, setAddForm] = useState<AddMemberForm>(defaultAddForm);
+  const [profileOptions, setProfileOptions] = useState<StaffProfileOption[]>([]);
+  const [profileLoading, setProfileLoading] = useState(false);
   const [addLoading, setAddLoading] = useState(false);
   const [addError, setAddError] = useState<string | undefined>();
   const [actionId, setActionId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | undefined>();
+  const [managedMember, setManagedMember] = useState<GymMemberDirectoryItem | null>(null);
+  const [managedCoachId, setManagedCoachId] = useState("");
+  const [planTitle, setPlanTitle] = useState("");
+  const [planGoal, setPlanGoal] = useState("");
+  const [planNotes, setPlanNotes] = useState("");
+  const [manageLoading, setManageLoading] = useState(false);
+  const [manageError, setManageError] = useState<string | undefined>();
+  const [inviteLabel, setInviteLabel] = useState("Front desk invite");
+  const [inviteAccess, setInviteAccess] = useState<"active" | "pending">("active");
+  const [inviteLimit, setInviteLimit] = useState("25");
+  const [inviteLoading, setInviteLoading] = useState(false);
+  const [inviteError, setInviteError] = useState<string | undefined>();
+  const [qrCodes, setQrCodes] = useState<Record<string, string>>({});
+  const [requestActionId, setRequestActionId] = useState<string | null>(null);
 
   const { status, data, error, refetch } = useAsync(
-    () => gym.listGymMemberships(gymId),
+    () => gym.listGymMemberDirectory(gymId),
     [gymId]
   );
 
+  const staffOptionsState = useAsync(
+    () => gym.listStaffProfileOptions(gymId),
+    [gymId]
+  );
+
+  const inviteCodesState = useAsync(
+    () => gym.listGymInviteCodes(gymId),
+    [gymId]
+  );
+
+  const joinRequestsState = useAsync(
+    () => gym.listGymJoinRequests(gymId, "pending"),
+    [gymId]
+  );
+
+  useEffect(() => {
+    let active = true;
+    const query = addForm.profileQuery.trim();
+
+    if (!showAdd || query.length < 2) {
+      setProfileOptions([]);
+      setProfileLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
+    const timeout = window.setTimeout(async () => {
+      setProfileLoading(true);
+      try {
+        const profiles = await gym.searchProfiles(gymId, query);
+        if (active) setProfileOptions(profiles);
+      } catch (profileError) {
+        if (active) setAddError(profileError instanceof Error ? profileError.message : "Profile search failed.");
+      } finally {
+        if (active) setProfileLoading(false);
+      }
+    }, 250);
+
+    return () => {
+      active = false;
+      window.clearTimeout(timeout);
+    };
+  }, [addForm.profileQuery, gym, gymId, showAdd]);
+
+  useEffect(() => {
+    let active = true;
+    const invites = (inviteCodesState.data ?? []).filter((invite) => invite.isActive).slice(0, 3);
+
+    if (invites.length === 0) {
+      setQrCodes({});
+      return () => {
+        active = false;
+      };
+    }
+
+    Promise.all(
+      invites.map(async (invite) => {
+        const dataUrl = await QRCode.toDataURL(inviteUrl(invite.code), {
+          margin: 1,
+          width: 144,
+          color: {
+            dark: "#0E1116",
+            light: "#FFFFFF",
+          },
+        });
+        return [invite.id, dataUrl] as const;
+      })
+    )
+      .then((entries) => {
+        if (active) setQrCodes(Object.fromEntries(entries));
+      })
+      .catch(() => {
+        if (active) setQrCodes({});
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [inviteCodesState.data]);
+
+  const staffOptions = staffOptionsState.data ?? [];
+
   const handleAddMember = async () => {
     if (!addForm.userId.trim()) {
-      setAddError("User ID is required.");
+      setAddError("Pick a profile from search results. For a brand-new person, invite them first so their profile exists.");
       return;
     }
     setAddLoading(true);
     setAddError(undefined);
     try {
-      await gym.addOrUpdateMembership(gymId, {
+      const membership = await gym.addOrUpdateMembership(gymId, {
         userId: addForm.userId.trim(),
         role: addForm.role,
         membershipStatus: addForm.membershipStatus,
       });
+      if (addForm.coachUserId) {
+        await gym.assignMembershipCoach(gymId, membership.id, addForm.coachUserId);
+      }
       setShowAdd(false);
       setAddForm(defaultAddForm);
+      setProfileOptions([]);
       refetch();
     } catch (e) {
       setAddError(e instanceof Error ? e.message : "Failed to add member");
@@ -96,12 +269,112 @@ export default function MembersPage() {
     [gym, gymId, refetch]
   );
 
+  const openManageModal = (member: GymMemberDirectoryItem) => {
+    setManagedMember(member);
+    setManagedCoachId(member.coachUserId ?? "");
+    setPlanTitle("");
+    setPlanGoal("");
+    setPlanNotes("");
+    setManageError(undefined);
+  };
+
+  const handleSaveCoach = async () => {
+    if (!managedMember) return;
+    setManageLoading(true);
+    setManageError(undefined);
+    try {
+      await gym.assignMembershipCoach(gymId, managedMember.id, managedCoachId || null);
+      refetch();
+    } catch (e) {
+      setManageError(e instanceof Error ? e.message : "Unable to update personal trainer.");
+    } finally {
+      setManageLoading(false);
+    }
+  };
+
+  const handleCreateWorkoutPlan = async () => {
+    if (!managedMember) return;
+    if (!planTitle.trim()) {
+      setManageError("Workout plan title is required.");
+      return;
+    }
+    setManageLoading(true);
+    setManageError(undefined);
+    try {
+      await gym.createMemberWorkoutPlan(gymId, {
+        memberUserId: managedMember.userId,
+        coachUserId: managedCoachId || managedMember.coachUserId || null,
+        title: planTitle.trim(),
+        goal: planGoal.trim() || null,
+        status: "active",
+        planJson: {
+          notes: planNotes.trim(),
+          source: "admin_members_page"
+        },
+      });
+      setPlanTitle("");
+      setPlanGoal("");
+      setPlanNotes("");
+      refetch();
+    } catch (e) {
+      setManageError(e instanceof Error ? e.message : "Unable to create workout plan.");
+    } finally {
+      setManageLoading(false);
+    }
+  };
+
+  const handleCreateInvite = async () => {
+    setInviteLoading(true);
+    setInviteError(undefined);
+    try {
+      await gym.createGymInviteCode(gymId, {
+        label: inviteLabel.trim() || "Gym invite",
+        membershipStatus: inviteAccess,
+        maxRedemptions: inviteLimit.trim() ? Number(inviteLimit) : null,
+      });
+      inviteCodesState.refetch();
+    } catch (e) {
+      setInviteError(e instanceof Error ? e.message : "Unable to create invite link.");
+    } finally {
+      setInviteLoading(false);
+    }
+  };
+
+  const handleReviewJoinRequest = async (
+    request: GymJoinRequestDirectoryItem,
+    nextStatus: "approved" | "rejected"
+  ) => {
+    setRequestActionId(request.id);
+    setActionError(undefined);
+    try {
+      await gym.reviewGymJoinRequest(gymId, {
+        requestId: request.id,
+        nextStatus,
+      });
+      joinRequestsState.refetch();
+      refetch();
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : "Unable to review access request.");
+    } finally {
+      setRequestActionId(null);
+    }
+  };
+
+  const copyInvite = async (invite: GymInviteCode) => {
+    try {
+      await navigator.clipboard.writeText(inviteUrl(invite.code));
+      setInviteError(undefined);
+    } catch {
+      setInviteError("Copy failed. Select and copy the invite link manually.");
+    }
+  };
+
   if (status === "loading" || status === "idle") return <PageSkeleton />;
 
   if (status === "error") {
     return (
       <div className="space-y-6">
-        <PageHeader title="Members" description="Manage gym memberships, roles, and access." />
+        <PageHeader title="Members" description="Manage gym members, roles, personal trainers, and workout plans." />
         <ErrorBanner message={error} onRetry={refetch} />
       </div>
     );
@@ -109,27 +382,41 @@ export default function MembersPage() {
 
   const members = data ?? [];
 
-  const filtered = members.filter((m) => {
-    if (statusFilter !== "all" && m.membershipStatus !== statusFilter) return false;
+  const filtered = members.filter((member) => {
+    if (statusFilter !== "all" && member.membershipStatus !== statusFilter) return false;
     if (search) {
-      const q = search.toLowerCase();
-      if (!m.userId.toLowerCase().includes(q) && !m.role.toLowerCase().includes(q)) return false;
+      const query = search.toLowerCase();
+      const haystack = [
+        member.userId,
+        member.role,
+        member.profile?.displayName,
+        member.profile?.username,
+        member.coachProfile?.displayName,
+        member.coachProfile?.username,
+        member.latestWorkoutPlan?.title,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(query)) return false;
     }
     return true;
   });
 
   const activeCount = members.filter((m) => m.membershipStatus === "active").length;
   const pendingCount = members.filter((m) => m.membershipStatus === "pending").length;
-  const trialCount = members.filter((m) => m.membershipStatus === "trial").length;
+  const coachedCount = members.filter((m) => Boolean(m.coachUserId)).length;
+  const pendingRequests = joinRequestsState.data ?? [];
+  const activeInvites = (inviteCodesState.data ?? []).filter((invite) => invite.isActive);
 
-  const columns: Column<GymMembership>[] = [
+  const columns: Column<GymMemberDirectoryItem>[] = [
     {
       key: "name",
       header: "Member",
       sortable: true,
       render: (row) => (
         <div>
-          <p className="font-medium text-foreground">{row.userId.slice(0, 8)}</p>
+          <p className="font-medium text-foreground">{memberLabel(row)}</p>
           <p className="text-xs text-muted-foreground">{row.userId}</p>
         </div>
       ),
@@ -137,20 +424,37 @@ export default function MembersPage() {
     {
       key: "role",
       header: "Role",
-      render: (row) => (
-        <span className="text-sm capitalize text-muted-foreground">{row.role}</span>
-      ),
+      render: (row) => <span className="text-sm capitalize text-muted-foreground">{row.role}</span>,
     },
     {
       key: "membershipStatus",
       header: "Status",
       render: (row) => (
-        <StatusBadge
-          label={row.membershipStatus}
-          variant={statusToVariant(row.membershipStatus)}
-          dot
-        />
+        <StatusBadge label={row.membershipStatus} variant={statusToVariant(row.membershipStatus)} dot />
       ),
+    },
+    {
+      key: "coach",
+      header: "PT",
+      render: (row) =>
+        row.coachProfile ? (
+          <span className="text-sm text-foreground">{row.coachProfile.label}</span>
+        ) : (
+          <span className="text-xs text-muted-foreground">Unassigned</span>
+        ),
+    },
+    {
+      key: "plan",
+      header: "Workout Plan",
+      render: (row) =>
+        row.latestWorkoutPlan ? (
+          <div>
+            <p className="text-sm font-medium text-foreground">{row.latestWorkoutPlan.title}</p>
+            <p className="text-xs capitalize text-muted-foreground">{row.latestWorkoutPlan.status}</p>
+          </div>
+        ) : (
+          <span className="text-xs text-muted-foreground">No plan</span>
+        ),
     },
     {
       key: "startedAt",
@@ -158,72 +462,53 @@ export default function MembersPage() {
       sortable: true,
       render: (row) => (
         <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
-          {row.startedAt
-            ? new Date(row.startedAt).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                year: "numeric",
-              })
-            : "—"}
+          {formatDate(row.startedAt)}
         </span>
       ),
     },
     {
-      key: "endsAt",
-      header: "Ends",
-      render: (row) =>
-        row.endsAt ? (
-          <span className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
-            {new Date(row.endsAt).toLocaleDateString("en-US", {
-              month: "short",
-              day: "numeric",
-              year: "numeric",
-            })}
-          </span>
-        ) : (
-          <span className="text-xs text-muted-foreground">—</span>
-        ),
-    },
-    {
       key: "actions",
       header: "",
-      className: "w-32",
+      className: "w-44",
       render: (row) => {
         const loading = actionId === row.id;
-        if (row.membershipStatus === "pending") {
-          return (
+        return (
+          <div className="flex flex-wrap gap-2">
+            {row.membershipStatus === "pending" && (
+              <button
+                onClick={() => handleStatusChange(row.id, "active")}
+                disabled={loading}
+                className="rounded-button bg-kruxt-success/15 px-2.5 py-1 text-xs font-medium text-kruxt-success transition-colors hover:bg-kruxt-success/25 disabled:opacity-50"
+              >
+                {loading ? "..." : "Approve"}
+              </button>
+            )}
+            {(row.membershipStatus === "active" || row.membershipStatus === "trial") && (
+              <button
+                onClick={() => handleStatusChange(row.id, "paused")}
+                disabled={loading}
+                className="rounded-button border border-kruxt-warning/40 px-2.5 py-1 text-xs font-medium text-kruxt-warning transition-colors hover:bg-kruxt-warning/10 disabled:opacity-50"
+              >
+                {loading ? "..." : "Pause"}
+              </button>
+            )}
+            {row.membershipStatus === "paused" && (
+              <button
+                onClick={() => handleStatusChange(row.id, "active")}
+                disabled={loading}
+                className="rounded-button bg-kruxt-accent/15 px-2.5 py-1 text-xs font-medium text-kruxt-accent transition-colors hover:bg-kruxt-accent/25 disabled:opacity-50"
+              >
+                {loading ? "..." : "Reactivate"}
+              </button>
+            )}
             <button
-              onClick={() => handleStatusChange(row.id, "active")}
-              disabled={loading}
-              className="rounded-button bg-kruxt-success/15 px-2.5 py-1 text-xs font-medium text-kruxt-success transition-colors hover:bg-kruxt-success/25 disabled:opacity-50"
+              onClick={() => openManageModal(row)}
+              className="rounded-button border border-border px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-kruxt-panel"
             >
-              {loading ? "…" : "Approve"}
+              Manage
             </button>
-          );
-        }
-        if (row.membershipStatus === "active" || row.membershipStatus === "trial") {
-          return (
-            <button
-              onClick={() => handleStatusChange(row.id, "paused")}
-              disabled={loading}
-              className="rounded-button border border-kruxt-warning/40 px-2.5 py-1 text-xs font-medium text-kruxt-warning transition-colors hover:bg-kruxt-warning/10 disabled:opacity-50"
-            >
-              {loading ? "…" : "Pause"}
-            </button>
-          );
-        }
-        if (row.membershipStatus === "paused") {
-          return (
-            <button
-              onClick={() => handleStatusChange(row.id, "active")}
-              disabled={loading}
-              className="rounded-button bg-kruxt-accent/15 px-2.5 py-1 text-xs font-medium text-kruxt-accent transition-colors hover:bg-kruxt-accent/25 disabled:opacity-50"
-            >
-              {loading ? "…" : "Reactivate"}
-            </button>
-          );
-        }
-        return null;
+          </div>
+        );
       },
     },
   ];
@@ -232,7 +517,7 @@ export default function MembersPage() {
     <div className="space-y-6">
       <PageHeader
         title="Members"
-        description="Manage gym memberships, roles, and access."
+        description="Manage real profiles, access, assigned PTs, and member workout plans."
         actions={
           <button
             onClick={() => setShowAdd(true)}
@@ -243,107 +528,225 @@ export default function MembersPage() {
         }
       />
 
-      {actionError && (
-        <ErrorBanner message={actionError} onRetry={() => setActionError(undefined)} />
-      )}
+      {actionError && <ErrorBanner message={actionError} onRetry={() => setActionError(undefined)} />}
 
-      {/* Stats */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <StatCard label="Active Members" value={activeCount} accent="success" />
-        <StatCard label="Pending Approval" value={pendingCount} accent="warning" />
-        <StatCard label="On Trial" value={trialCount} accent="default" />
+        <StatCard label="Pending Approval" value={pendingCount + pendingRequests.length} accent="warning" />
+        <StatCard label="Assigned PT" value={coachedCount} accent="default" />
       </div>
 
-      {/* Filters */}
+      <section className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <div className="rounded-card border border-border bg-card p-5">
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-sm font-semibold text-foreground font-kruxt-headline">Pending Gym Access</h2>
+              <p className="text-xs text-muted-foreground">
+                Members create public profiles themselves, then request access to this gym's private area.
+              </p>
+            </div>
+            <button
+              onClick={joinRequestsState.refetch}
+              className="rounded-button border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-kruxt-panel"
+            >
+              Refresh
+            </button>
+          </div>
+          {joinRequestsState.status === "error" && (
+            <p className="mt-3 rounded-lg bg-kruxt-danger/10 px-3 py-2 text-xs text-kruxt-danger">
+              {joinRequestsState.error}
+            </p>
+          )}
+          {pendingRequests.length === 0 ? (
+            <p className="mt-4 text-sm text-muted-foreground">No pending access requests.</p>
+          ) : (
+            <div className="mt-4 divide-y divide-border rounded-lg border border-border">
+              {pendingRequests.map((request) => {
+                const loading = requestActionId === request.id;
+                return (
+                  <div key={request.id} className="flex flex-col gap-3 p-3 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        {request.profile?.label ?? request.userId.slice(0, 8)}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {request.source === "invite_code" ? `Invite: ${request.inviteLabel ?? "code"}` : "Public request"}
+                        {request.membershipPlanName ? ` / ${request.membershipPlanName}` : ""}
+                      </p>
+                      {request.note && <p className="mt-1 text-xs text-muted-foreground">{request.note}</p>}
+                    </div>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => handleReviewJoinRequest(request, "approved")}
+                        disabled={loading}
+                        className="rounded-button bg-kruxt-success/15 px-3 py-1.5 text-xs font-semibold text-kruxt-success transition-colors hover:bg-kruxt-success/25 disabled:opacity-50"
+                      >
+                        {loading ? "..." : "Approve"}
+                      </button>
+                      <button
+                        onClick={() => handleReviewJoinRequest(request, "rejected")}
+                        disabled={loading}
+                        className="rounded-button border border-kruxt-danger/40 px-3 py-1.5 text-xs font-semibold text-kruxt-danger transition-colors hover:bg-kruxt-danger/10 disabled:opacity-50"
+                      >
+                        Reject
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-card border border-border bg-card p-5">
+          <h2 className="text-sm font-semibold text-foreground font-kruxt-headline">Invite Link / QR</h2>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Use this for reception, posters, or DMs. The QR opens the join flow with the code prefilled.
+          </p>
+          {inviteError && (
+            <p className="mt-3 rounded-lg bg-kruxt-danger/10 px-3 py-2 text-xs text-kruxt-danger">{inviteError}</p>
+          )}
+          <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-[1fr_130px]">
+            <input
+              value={inviteLabel}
+              onChange={(event) => setInviteLabel(event.target.value)}
+              className={INPUT}
+              placeholder="Invite label"
+            />
+            <input
+              value={inviteLimit}
+              onChange={(event) => setInviteLimit(event.target.value.replace(/\D/g, ""))}
+              className={INPUT}
+              placeholder="Limit"
+            />
+            <select
+              value={inviteAccess}
+              onChange={(event) => setInviteAccess(event.target.value as "active" | "pending")}
+              className={INPUT}
+            >
+              <option value="active">Instant private access</option>
+              <option value="pending">Request approval after scan</option>
+            </select>
+            <button
+              onClick={handleCreateInvite}
+              disabled={inviteLoading}
+              className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {inviteLoading ? "Creating..." : "Create"}
+            </button>
+          </div>
+          <div className="mt-4 space-y-3">
+            {activeInvites.slice(0, 3).map((invite) => (
+              <div key={invite.id} className="rounded-lg border border-border bg-kruxt-panel/35 p-3">
+                <div className="flex gap-3">
+                  {qrCodes[invite.id] ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={qrCodes[invite.id]} alt="" className="h-24 w-24 rounded-md bg-white p-1" />
+                  ) : (
+                    <div className="h-24 w-24 rounded-md bg-card" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-semibold text-foreground">{invite.label || invite.code}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {invite.membershipStatus === "active" ? "Instant access" : "Approval required"} / {invite.redeemedCount}
+                      {invite.maxRedemptions ? ` of ${invite.maxRedemptions}` : ""} used
+                    </p>
+                    <input
+                      readOnly
+                      value={inviteUrl(invite.code)}
+                      className="mt-2 w-full rounded-md border border-border bg-card px-2 py-1 text-xs text-muted-foreground outline-none font-kruxt-mono"
+                    />
+                    <div className="mt-2 flex gap-2">
+                      <button
+                        onClick={() => copyInvite(invite)}
+                        className="rounded-button border border-border px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-card"
+                      >
+                        Copy Link
+                      </button>
+                      <button
+                        onClick={() => gym.updateGymInviteCode(gymId, invite.id, { isActive: false }).then(inviteCodesState.refetch)}
+                        className="rounded-button border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-card"
+                      >
+                        Disable
+                      </button>
+                    </div>
+                    <p className="mt-2 text-[10px] text-muted-foreground">Expires: {formatDateTime(invite.expiresAt)}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+            {activeInvites.length === 0 && (
+              <p className="text-sm text-muted-foreground">No active invite links yet.</p>
+            )}
+          </div>
+        </div>
+      </section>
+
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex items-center gap-1 rounded-lg border border-border bg-card p-1">
-          {statusFilters.map((f) => (
+          {statusFilters.map((filter) => (
             <button
-              key={f.value}
-              onClick={() => setStatusFilter(f.value)}
+              key={filter.value}
+              onClick={() => setStatusFilter(filter.value)}
               className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                statusFilter === f.value
+                statusFilter === filter.value
                   ? "bg-kruxt-accent/15 text-kruxt-accent"
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >
-              {f.label}
+              {filter.label}
             </button>
           ))}
         </div>
         <div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5">
-          <svg
-            className="h-4 w-4 text-muted-foreground"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={1.5}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-            />
+          <svg className="h-4 w-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
           </svg>
           <input
             type="text"
-            placeholder="Search members..."
+            placeholder="Search members, PTs, plans..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-48 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+            className="w-64 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
           />
         </div>
       </div>
 
-      {/* Table */}
       {filtered.length === 0 ? (
         <EmptyState
           title="No members found"
           description={
             members.length === 0
-              ? "Your gym doesn't have any members yet. Add your first member to get started."
+              ? "Your gym does not have any members yet. Add an existing profile or send an invite."
               : "Try adjusting your filters or search terms."
           }
           icon={
-            <svg
-              className="h-10 w-10"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={1}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
-              />
+            <svg className="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
             </svg>
           }
         />
       ) : (
-        <DataTable
-          columns={columns}
-          data={filtered}
-          keyExtractor={(row) => row.id}
-        />
+        <DataTable columns={columns} data={filtered} keyExtractor={(row) => row.id} />
       )}
 
-      {/* Add Member Modal */}
       <Modal
         open={showAdd}
         onClose={() => {
           setShowAdd(false);
           setAddForm(defaultAddForm);
+          setProfileOptions([]);
           setAddError(undefined);
         }}
         title="Add Member"
-        size="sm"
+        size="lg"
         footer={
           <>
             <button
               onClick={() => {
                 setShowAdd(false);
                 setAddForm(defaultAddForm);
+                setProfileOptions([]);
                 setAddError(undefined);
               }}
               className="rounded-button border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-kruxt-panel"
@@ -355,60 +758,170 @@ export default function MembersPage() {
               disabled={addLoading}
               className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
             >
-              {addLoading ? "Adding…" : "Add Member"}
+              {addLoading ? "Adding..." : "Add Member"}
             </button>
           </>
         }
       >
-        {addError && (
-          <p className="rounded-lg bg-kruxt-danger/10 px-3 py-2 text-xs text-kruxt-danger">
-            {addError}
-          </p>
-        )}
+        {addError && <p className="rounded-lg bg-kruxt-danger/10 px-3 py-2 text-xs text-kruxt-danger">{addError}</p>}
         <div>
           <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-            User ID *
+            Search profile by name or username
           </label>
           <input
             type="text"
-            placeholder="Supabase user UUID…"
-            value={addForm.userId}
-            onChange={(e) => setAddForm((f) => ({ ...f, userId: e.target.value }))}
-            className={INPUT}
-          />
-          <p className="mt-1 text-[10px] text-muted-foreground">
-            Find the user&apos;s UUID in Supabase → Authentication → Users
-          </p>
-        </div>
-        <div>
-          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Role</label>
-          <select
-            value={addForm.role}
-            onChange={(e) => setAddForm((f) => ({ ...f, role: e.target.value as GymRole }))}
-            className={INPUT}
-          >
-            <option value="member">Member</option>
-            <option value="coach">Coach</option>
-            <option value="officer">Officer</option>
-            <option value="leader">Leader</option>
-          </select>
-        </div>
-        <div>
-          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-            Initial Status
-          </label>
-          <select
-            value={addForm.membershipStatus}
+            placeholder="Mario Rossi, @mario..."
+            value={addForm.profileQuery}
             onChange={(e) =>
-              setAddForm((f) => ({ ...f, membershipStatus: e.target.value as MembershipStatus }))
+              setAddForm((form) => ({ ...form, profileQuery: e.target.value, userId: "" }))
             }
             className={INPUT}
+          />
+          <ProfileSearchResults
+            options={profileOptions}
+            loading={profileLoading}
+            onSelect={(option) => {
+              setAddForm((form) => ({
+                ...form,
+                userId: option.userId,
+                profileQuery: option.label,
+              }));
+              setProfileOptions([]);
+            }}
+          />
+          {addForm.userId && (
+            <p className="mt-2 text-xs text-kruxt-success">Selected profile: {addForm.profileQuery}</p>
+          )}
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Role</label>
+            <select
+              value={addForm.role}
+              onChange={(e) => setAddForm((form) => ({ ...form, role: e.target.value as GymRole }))}
+              className={INPUT}
+            >
+              <option value="member">Member</option>
+              <option value="coach">Coach</option>
+              <option value="officer">Officer</option>
+              <option value="leader">Leader</option>
+            </select>
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Initial Status</label>
+            <select
+              value={addForm.membershipStatus}
+              onChange={(e) =>
+                setAddForm((form) => ({ ...form, membershipStatus: e.target.value as MembershipStatus }))
+              }
+              className={INPUT}
+            >
+              <option value="active">Active</option>
+              <option value="trial">Trial</option>
+              <option value="pending">Pending</option>
+            </select>
+          </div>
+        </div>
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Assigned PT</label>
+          <select
+            value={addForm.coachUserId}
+            onChange={(e) => setAddForm((form) => ({ ...form, coachUserId: e.target.value }))}
+            className={INPUT}
           >
-            <option value="active">Active</option>
-            <option value="trial">Trial</option>
-            <option value="pending">Pending (requires approval)</option>
+            <option value="">No PT assigned</option>
+            {staffOptions.map((staff) => (
+              <option key={staff.userId} value={staff.userId}>
+                {staff.label}
+              </option>
+            ))}
           </select>
         </div>
+      </Modal>
+
+      <Modal
+        open={Boolean(managedMember)}
+        onClose={() => setManagedMember(null)}
+        title={managedMember ? `Manage ${memberLabel(managedMember)}` : "Manage Member"}
+        size="lg"
+        footer={
+          <>
+            <button
+              onClick={() => setManagedMember(null)}
+              className="rounded-button border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-kruxt-panel"
+            >
+              Close
+            </button>
+          </>
+        }
+      >
+        {manageError && <p className="rounded-lg bg-kruxt-danger/10 px-3 py-2 text-xs text-kruxt-danger">{manageError}</p>}
+        {managedMember && (
+          <>
+            <div className="rounded-lg border border-border bg-kruxt-panel/30 p-4">
+              <p className="text-sm font-semibold text-foreground">{memberLabel(managedMember)}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {managedMember.role} / {managedMember.membershipStatus}
+              </p>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Latest plan: {managedMember.latestWorkoutPlan?.title ?? "No workout plan logged yet."}
+              </p>
+            </div>
+            <div className="space-y-3">
+              <label className="block text-xs font-medium text-muted-foreground">Assigned personal trainer</label>
+              <div className="flex gap-2">
+                <select
+                  value={managedCoachId}
+                  onChange={(e) => setManagedCoachId(e.target.value)}
+                  className={INPUT}
+                >
+                  <option value="">No PT assigned</option>
+                  {staffOptions.map((staff) => (
+                    <option key={staff.userId} value={staff.userId}>
+                      {staff.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleSaveCoach}
+                  disabled={manageLoading}
+                  className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+            <div className="space-y-3 rounded-lg border border-border bg-card p-4">
+              <p className="text-sm font-semibold text-foreground">Log workout plan</p>
+              <input
+                className={INPUT}
+                value={planTitle}
+                onChange={(e) => setPlanTitle(e.target.value)}
+                placeholder="4-week strength base"
+              />
+              <input
+                className={INPUT}
+                value={planGoal}
+                onChange={(e) => setPlanGoal(e.target.value)}
+                placeholder="Goal, e.g. rebuild squat pattern and improve consistency"
+              />
+              <textarea
+                rows={4}
+                className={INPUT}
+                value={planNotes}
+                onChange={(e) => setPlanNotes(e.target.value)}
+                placeholder="Weekly structure, exercises, constraints, notes for the PT..."
+              />
+              <button
+                onClick={handleCreateWorkoutPlan}
+                disabled={manageLoading}
+                className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+              >
+                {manageLoading ? "Saving..." : "Save Workout Plan"}
+              </button>
+            </div>
+          </>
+        )}
       </Modal>
     </div>
   );

--- a/apps/admin/src/app/(dashboard)/settings/page.tsx
+++ b/apps/admin/src/app/(dashboard)/settings/page.tsx
@@ -1,166 +1,325 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PageHeader } from "@/components/page-header";
+import { ErrorBanner } from "@/components/error-banner";
 import { PageSkeleton } from "@/components/loading-skeleton";
+import { useGym } from "@/contexts/gym-context";
+import { useServices } from "@/hooks/use-services";
+import { useAsync } from "@/hooks/use-async";
+import { seedBzoneDemoData } from "@/services";
+import type { UpsertGymBrandSettingsInput } from "@kruxt/types";
 
-interface SettingsSection {
-  id: string;
-  title: string;
-  description: string;
-  icon: JSX.Element;
+const INPUT =
+  "w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent/40";
+
+interface BrandDraft {
+  appDisplayName: string;
+  logoUrl: string;
+  iconUrl: string;
+  bannerUrl: string;
+  primaryColor: string;
+  accentColor: string;
+  backgroundColor: string;
+  surfaceColor: string;
+  textColor: string;
+  launchScreenMessage: string;
+  supportEmail: string;
+  termsUrl: string;
+  privacyUrl: string;
 }
 
-const sections: SettingsSection[] = [
-  {
-    id: "gym",
-    title: "Gym Profile",
-    description: "Name, logo, address, operating hours, and contact info.",
-    icon: (
-      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 0h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z" />
-      </svg>
-    ),
-  },
-  {
-    id: "staff",
-    title: "Staff & Roles",
-    description: "Manage admin accounts, coaches, and permission levels.",
-    icon: (
-      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
-      </svg>
-    ),
-  },
-  {
-    id: "membership",
-    title: "Membership Plans",
-    description: "Configure plan tiers, pricing, trial periods, and billing cycles.",
-    icon: (
-      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z" />
-      </svg>
-    ),
-  },
-  {
-    id: "notifications",
-    title: "Notifications",
-    description: "Email templates, push notification settings, and alert rules.",
-    icon: (
-      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
-      </svg>
-    ),
-  },
-  {
-    id: "branding",
-    title: "Branding & Theme",
-    description: "Customize colors, logo, and the member-facing app experience.",
-    icon: (
-      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M9.53 16.122a3 3 0 00-5.78 1.128 2.25 2.25 0 01-2.4 2.245 4.5 4.5 0 008.4-2.245c0-.399-.078-.78-.22-1.128zm0 0a15.998 15.998 0 003.388-1.62m-5.043-.025a15.994 15.994 0 011.622-3.395m3.42 3.42a15.995 15.995 0 004.764-4.648l3.876-5.814a1.151 1.151 0 00-1.597-1.597L14.146 6.32a15.996 15.996 0 00-4.649 4.763m3.42 3.42a6.776 6.776 0 00-3.42-3.42" />
-      </svg>
-    ),
-  },
-  {
-    id: "security",
-    title: "Security",
-    description: "Two-factor enforcement, session timeout, and API key management.",
-    icon: (
-      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-      </svg>
-    ),
-  },
-];
+const defaultBrandDraft: BrandDraft = {
+  appDisplayName: "",
+  logoUrl: "",
+  iconUrl: "",
+  bannerUrl: "",
+  primaryColor: "#35D0FF",
+  accentColor: "#8BE9C7",
+  backgroundColor: "#0E1116",
+  surfaceColor: "#171C24",
+  textColor: "#F5F7FA",
+  launchScreenMessage: "",
+  supportEmail: "",
+  termsUrl: "",
+  privacyUrl: "",
+};
+
+function compact(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function toDraft(settings: Awaited<ReturnType<ReturnType<typeof useServices>["customization"]["getGymBrandSettings"]>>): BrandDraft {
+  if (!settings) return defaultBrandDraft;
+  return {
+    appDisplayName: settings.appDisplayName ?? "",
+    logoUrl: settings.logoUrl ?? "",
+    iconUrl: settings.iconUrl ?? "",
+    bannerUrl: settings.bannerUrl ?? "",
+    primaryColor: settings.primaryColor ?? defaultBrandDraft.primaryColor,
+    accentColor: settings.accentColor ?? defaultBrandDraft.accentColor,
+    backgroundColor: settings.backgroundColor ?? defaultBrandDraft.backgroundColor,
+    surfaceColor: settings.surfaceColor ?? defaultBrandDraft.surfaceColor,
+    textColor: settings.textColor ?? defaultBrandDraft.textColor,
+    launchScreenMessage: settings.launchScreenMessage ?? "",
+    supportEmail: settings.supportEmail ?? "",
+    termsUrl: settings.termsUrl ?? "",
+    privacyUrl: settings.privacyUrl ?? "",
+  };
+}
 
 export default function SettingsPage() {
-  const [loading] = useState(false);
-  const [activeSection, setActiveSection] = useState<string | null>(null);
+  const { gymId, gymName } = useGym();
+  const { customization, supabase } = useServices();
+  const [draft, setDraft] = useState<BrandDraft>(defaultBrandDraft);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | undefined>();
+  const [success, setSuccess] = useState<string | undefined>();
+  const [seeding, setSeeding] = useState(false);
+  const [seedMessage, setSeedMessage] = useState<string | undefined>();
 
-  if (loading) return <PageSkeleton />;
+  const brandState = useAsync(() => customization.getGymBrandSettings(gymId), [gymId]);
+
+  useEffect(() => {
+    if (brandState.status === "success") {
+      setDraft(toDraft(brandState.data ?? null));
+    }
+  }, [brandState.data, brandState.status]);
+
+  const updateDraft = (key: keyof BrandDraft, value: string) => {
+    setDraft((current) => ({ ...current, [key]: value }));
+    setSuccess(undefined);
+  };
+
+  const saveBranding = async () => {
+    setSaving(true);
+    setSaveError(undefined);
+    setSuccess(undefined);
+    try {
+      const input: UpsertGymBrandSettingsInput = {
+        appDisplayName: compact(draft.appDisplayName),
+        logoUrl: compact(draft.logoUrl),
+        iconUrl: compact(draft.iconUrl),
+        bannerUrl: compact(draft.bannerUrl),
+        primaryColor: draft.primaryColor,
+        accentColor: draft.accentColor,
+        backgroundColor: draft.backgroundColor,
+        surfaceColor: draft.surfaceColor,
+        textColor: draft.textColor,
+        launchScreenMessage: compact(draft.launchScreenMessage),
+        supportEmail: compact(draft.supportEmail),
+        termsUrl: compact(draft.termsUrl),
+        privacyUrl: compact(draft.privacyUrl),
+      };
+      await customization.upsertGymBrandSettings(gymId, input);
+      setSuccess("Brand settings saved.");
+      brandState.refetch();
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "Unable to save brand settings.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const seedBzone = async () => {
+    setSeeding(true);
+    setSaveError(undefined);
+    setSeedMessage(undefined);
+    try {
+      const result = await seedBzoneDemoData(supabase, gymId);
+      setSeedMessage(
+        `BZone demo ready: ${result.plansUpserted} plans, ${
+          result.classesSkipped ? "existing class schedule kept" : `${result.classesCreated} classes`
+        }, waiver ${result.waiverUpserted ? "upserted" : "unchanged"}, and billing instructions ${
+          result.billingSettingsUpserted ? "upserted" : "unchanged"
+        }.`
+      );
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "Unable to seed BZone demo data.");
+    } finally {
+      setSeeding(false);
+    }
+  };
+
+  if (brandState.status === "loading" || brandState.status === "idle") return <PageSkeleton />;
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Settings"
-        description="Configure your gym platform."
+        description="Configure the member-facing gym experience, branding, and operational modules."
       />
 
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        {sections.map((section) => (
-          <button
-            key={section.id}
-            onClick={() => setActiveSection(activeSection === section.id ? null : section.id)}
-            className={`w-full text-left rounded-card border p-5 transition-all ${
-              activeSection === section.id
-                ? "border-kruxt-accent/40 bg-kruxt-accent/5"
-                : "border-border bg-card hover:bg-kruxt-panel/30"
-            }`}
-          >
-            <div className="flex items-start gap-4">
-              <div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl transition-colors ${
-                activeSection === section.id
-                  ? "bg-kruxt-accent/15 text-kruxt-accent"
-                  : "bg-kruxt-panel text-muted-foreground"
-              }`}>
-                {section.icon}
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-semibold text-foreground">
-                  {section.title}
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground leading-relaxed">
-                  {section.description}
-                </p>
-              </div>
-              <svg
-                className={`h-4 w-4 flex-shrink-0 text-muted-foreground transition-transform ${
-                  activeSection === section.id ? "rotate-90" : ""
-                }`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-              </svg>
+      {brandState.status === "error" && <ErrorBanner message={brandState.error} onRetry={brandState.refetch} />}
+      {saveError && <ErrorBanner message={saveError} onRetry={() => setSaveError(undefined)} />}
+      {success && (
+        <div className="rounded-card border border-kruxt-success/30 bg-kruxt-success/10 px-4 py-3 text-sm text-kruxt-success">
+          {success}
+        </div>
+      )}
+      {seedMessage && (
+        <div className="rounded-card border border-kruxt-success/30 bg-kruxt-success/10 px-4 py-3 text-sm text-kruxt-success">
+          {seedMessage}
+        </div>
+      )}
+
+      <section className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="rounded-card border border-border bg-card p-5">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-foreground font-kruxt-headline">
+              Branding & Member Page
+            </h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Owners can set the palette, logo, icon, banner, support contact, and launch copy shown to members.
+            </p>
+          </div>
+
+          <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Display name</label>
+              <input className={INPUT} value={draft.appDisplayName} onChange={(event) => updateDraft("appDisplayName", event.target.value)} placeholder={gymName} />
             </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Support email</label>
+              <input className={INPUT} value={draft.supportEmail} onChange={(event) => updateDraft("supportEmail", event.target.value)} placeholder="support@gym.com" />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Logo URL</label>
+              <input className={INPUT} value={draft.logoUrl} onChange={(event) => updateDraft("logoUrl", event.target.value)} placeholder="https://..." />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Icon URL</label>
+              <input className={INPUT} value={draft.iconUrl} onChange={(event) => updateDraft("iconUrl", event.target.value)} placeholder="https://..." />
+            </div>
+            <div className="lg:col-span-2">
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Banner URL</label>
+              <input className={INPUT} value={draft.bannerUrl} onChange={(event) => updateDraft("bannerUrl", event.target.value)} placeholder="https://..." />
+            </div>
+            <div className="lg:col-span-2">
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Launch screen message</label>
+              <textarea className={INPUT} rows={2} value={draft.launchScreenMessage} onChange={(event) => updateDraft("launchScreenMessage", event.target.value)} placeholder="Welcome back. No log, no legend." />
+            </div>
+          </div>
 
-            {/* Expanded placeholder */}
-            {activeSection === section.id && (
-              <div className="mt-4 rounded-lg border border-border bg-kruxt-panel/30 p-4">
-                <p className="text-xs text-muted-foreground">
-                  Configuration panel for <span className="font-medium text-foreground">{section.title}</span> will be available once the admin backend services are connected.
-                </p>
-                <div className="mt-3 flex gap-2">
-                  <span className="inline-flex items-center rounded-full bg-kruxt-accent/10 px-2 py-0.5 text-[10px] font-medium text-kruxt-accent">
-                    Coming Soon
+          <div className="mt-5 grid grid-cols-2 gap-3 lg:grid-cols-5">
+            {([
+              ["primaryColor", "Primary"],
+              ["accentColor", "Accent"],
+              ["backgroundColor", "Background"],
+              ["surfaceColor", "Surface"],
+              ["textColor", "Text"],
+            ] as const).map(([key, label]) => (
+              <label key={key} className="rounded-lg border border-border bg-kruxt-panel/40 p-3">
+                <span className="mb-2 block text-xs font-medium text-muted-foreground">{label}</span>
+                <input
+                  type="color"
+                  value={draft[key]}
+                  onChange={(event) => updateDraft(key, event.target.value)}
+                  className="h-10 w-full cursor-pointer rounded-md border border-border bg-transparent"
+                />
+                <input
+                  value={draft[key]}
+                  onChange={(event) => updateDraft(key, event.target.value)}
+                  className="mt-2 w-full bg-transparent text-xs text-foreground outline-none font-kruxt-mono"
+                />
+              </label>
+            ))}
+          </div>
+
+          <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Terms URL</label>
+              <input className={INPUT} value={draft.termsUrl} onChange={(event) => updateDraft("termsUrl", event.target.value)} placeholder="https://..." />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Privacy URL</label>
+              <input className={INPUT} value={draft.privacyUrl} onChange={(event) => updateDraft("privacyUrl", event.target.value)} placeholder="https://..." />
+            </div>
+          </div>
+
+          <div className="mt-5 flex justify-end">
+            <button
+              onClick={saveBranding}
+              disabled={saving}
+              className="rounded-button bg-kruxt-accent px-5 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? "Saving..." : "Save Branding"}
+            </button>
+          </div>
+        </div>
+
+        <aside className="overflow-hidden rounded-card border border-border bg-card">
+          <div
+            className="h-32 bg-cover bg-center"
+            style={{
+              backgroundColor: draft.backgroundColor,
+              backgroundImage: draft.bannerUrl ? `url(${draft.bannerUrl})` : undefined,
+            }}
+          />
+          <div className="p-5" style={{ backgroundColor: draft.surfaceColor, color: draft.textColor }}>
+            <div className="flex items-center gap-3">
+              <div
+                className="flex h-14 w-14 items-center justify-center overflow-hidden rounded-lg border"
+                style={{ borderColor: draft.primaryColor, backgroundColor: draft.backgroundColor }}
+              >
+                {draft.logoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={draft.logoUrl} alt="" className="h-full w-full object-cover" />
+                ) : (
+                  <span className="text-lg font-bold font-kruxt-headline" style={{ color: draft.primaryColor }}>
+                    {(draft.appDisplayName || gymName || "K").slice(0, 1).toUpperCase()}
                   </span>
-                </div>
+                )}
               </div>
-            )}
-          </button>
-        ))}
-      </div>
+              <div>
+                <p className="text-lg font-bold font-kruxt-headline">{draft.appDisplayName || gymName}</p>
+                <p className="text-xs opacity-70">Member page preview</p>
+              </div>
+            </div>
+            <p className="mt-5 text-sm opacity-90">{draft.launchScreenMessage || "No log, no legend."}</p>
+            <div className="mt-5 flex gap-2">
+              <span className="rounded-full px-3 py-1 text-xs font-semibold" style={{ backgroundColor: draft.primaryColor, color: draft.backgroundColor }}>
+                Primary
+              </span>
+              <span className="rounded-full px-3 py-1 text-xs font-semibold" style={{ backgroundColor: draft.accentColor, color: draft.backgroundColor }}>
+                Accent
+              </span>
+            </div>
+          </div>
+        </aside>
+      </section>
 
-      {/* Danger zone */}
-      <div className="rounded-card border border-kruxt-danger/30 bg-kruxt-danger/5 p-5">
-        <h3 className="text-sm font-semibold text-kruxt-danger font-kruxt-headline">
-          Danger Zone
-        </h3>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Irreversible actions. Proceed with extreme caution.
-        </p>
-        <div className="mt-4 flex flex-wrap gap-3">
-          <button className="rounded-button border border-kruxt-danger/40 px-3 py-1.5 text-xs font-medium text-kruxt-danger transition-colors hover:bg-kruxt-danger/10">
-            Reset All Member Data
-          </button>
-          <button className="rounded-button border border-kruxt-danger/40 px-3 py-1.5 text-xs font-medium text-kruxt-danger transition-colors hover:bg-kruxt-danger/10">
-            Delete Gym Account
+      <section className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        {[
+          ["Staff & Roles", "Use the Staff page to plan shifts; Members page assigns PTs and roles."],
+          ["Membership Plans", "Billing and plan configuration stays behind the billing_live rollout gate."],
+          ["Security", "MFA, trusted devices, and auth event views are next Phase 10 surfaces."],
+        ].map(([title, description]) => (
+          <div key={title} className="rounded-card border border-border bg-card p-5">
+            <p className="text-sm font-semibold text-foreground">{title}</p>
+            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">{description}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="rounded-card border border-border bg-card p-5">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground font-kruxt-headline">Demo Data</h2>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              Seed the current gym with BZone-style plans, a four-week class schedule, and the Italian waiver baseline.
+            </p>
+          </div>
+          <button
+            onClick={seedBzone}
+            disabled={seeding}
+            className="rounded-button bg-kruxt-accent px-5 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {seeding ? "Seeding..." : "Seed BZone Demo"}
           </button>
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/apps/admin/src/app/(dashboard)/staff/page.tsx
+++ b/apps/admin/src/app/(dashboard)/staff/page.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { PageHeader } from "@/components/page-header";
+import { StatCard } from "@/components/stat-card";
+import { DataTable, type Column } from "@/components/data-table";
+import { StatusBadge, statusToVariant } from "@/components/status-badge";
+import { ErrorBanner } from "@/components/error-banner";
+import { PageSkeleton } from "@/components/loading-skeleton";
+import { EmptyState } from "@/components/empty-state";
+import { useGym } from "@/contexts/gym-context";
+import { useServices } from "@/hooks/use-services";
+import { useAsync } from "@/hooks/use-async";
+import type { StaffShift, StaffShiftStatus } from "@kruxt/types";
+
+const INPUT =
+  "w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent/40";
+
+const SHIFT_STATUSES: StaffShiftStatus[] = [
+  "scheduled",
+  "confirmed",
+  "in_progress",
+  "completed",
+  "missed",
+  "cancelled",
+];
+
+function toDatetimeLocal(date: Date): string {
+  const offset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - offset * 60_000);
+  return local.toISOString().slice(0, 16);
+}
+
+function defaultStart(): string {
+  const date = new Date();
+  date.setHours(date.getHours() + 1, 0, 0, 0);
+  return toDatetimeLocal(date);
+}
+
+function defaultEnd(): string {
+  const date = new Date();
+  date.setHours(date.getHours() + 5, 0, 0, 0);
+  return toDatetimeLocal(date);
+}
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function StaffPage() {
+  const { gymId } = useGym();
+  const { gym } = useServices();
+  const [staffUserId, setStaffUserId] = useState("");
+  const [title, setTitle] = useState("Floor shift");
+  const [shiftRole, setShiftRole] = useState("coach");
+  const [startsAt, setStartsAt] = useState(defaultStart);
+  const [endsAt, setEndsAt] = useState(defaultEnd);
+  const [notes, setNotes] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [mutationError, setMutationError] = useState<string | undefined>();
+
+  const shiftsState = useAsync(() => gym.listStaffShifts(gymId), [gymId]);
+  const staffState = useAsync(() => gym.listStaffProfileOptions(gymId), [gymId]);
+
+  const staffById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const staff of staffState.data ?? []) {
+      map.set(staff.userId, staff.label);
+    }
+    return map;
+  }, [staffState.data]);
+
+  const createShift = async () => {
+    if (!staffUserId) {
+      setMutationError("Pick a staff member.");
+      return;
+    }
+    setCreating(true);
+    setMutationError(undefined);
+    try {
+      await gym.createStaffShift(gymId, {
+        staffUserId,
+        title,
+        shiftRole,
+        startsAt: new Date(startsAt).toISOString(),
+        endsAt: new Date(endsAt).toISOString(),
+        status: "scheduled",
+        notes: notes.trim() || undefined,
+      });
+      setTitle("Floor shift");
+      setShiftRole("coach");
+      setStartsAt(defaultStart());
+      setEndsAt(defaultEnd());
+      setNotes("");
+      shiftsState.refetch();
+    } catch (error) {
+      setMutationError(error instanceof Error ? error.message : "Unable to create shift.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const updateShiftStatus = async (shiftId: string, status: StaffShiftStatus) => {
+    setMutationError(undefined);
+    try {
+      await gym.updateStaffShift(gymId, shiftId, { status });
+      shiftsState.refetch();
+    } catch (error) {
+      setMutationError(error instanceof Error ? error.message : "Unable to update shift.");
+    }
+  };
+
+  if (shiftsState.status === "loading" || shiftsState.status === "idle") return <PageSkeleton />;
+
+  if (shiftsState.status === "error") {
+    return (
+      <div className="space-y-6">
+        <PageHeader title="Staff" description="Plan staff shifts and coverage." />
+        <ErrorBanner message={shiftsState.error} onRetry={shiftsState.refetch} />
+      </div>
+    );
+  }
+
+  const shifts = shiftsState.data ?? [];
+  const scheduledCount = shifts.filter((shift) => ["scheduled", "confirmed"].includes(shift.status)).length;
+  const activeCount = shifts.filter((shift) => shift.status === "in_progress").length;
+  const completedCount = shifts.filter((shift) => shift.status === "completed").length;
+
+  const columns: Column<StaffShift>[] = [
+    {
+      key: "title",
+      header: "Shift",
+      render: (row) => (
+        <div>
+          <p className="font-medium text-foreground">{row.title}</p>
+          <p className="text-xs text-muted-foreground">{row.shiftRole ?? "staff"}</p>
+        </div>
+      ),
+    },
+    {
+      key: "staff",
+      header: "Staff Member",
+      render: (row) => (
+        <span className="text-sm text-foreground">{staffById.get(row.staffUserId) ?? row.staffUserId.slice(0, 8)}</span>
+      ),
+    },
+    {
+      key: "time",
+      header: "Time",
+      render: (row) => (
+        <div className="text-sm tabular-nums text-muted-foreground font-kruxt-mono">
+          <p>{formatDateTime(row.startsAt)}</p>
+          <p>{formatDateTime(row.endsAt)}</p>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (row) => (
+        <StatusBadge label={row.status} variant={statusToVariant(row.status)} dot />
+      ),
+    },
+    {
+      key: "actions",
+      header: "",
+      className: "w-48",
+      render: (row) => (
+        <select
+          value={row.status}
+          onChange={(event) => void updateShiftStatus(row.id, event.target.value as StaffShiftStatus)}
+          className={INPUT}
+        >
+          {SHIFT_STATUSES.map((status) => (
+            <option key={status} value={status}>{status}</option>
+          ))}
+        </select>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Staff" description="Schedule coaches, officers, and desk coverage." />
+
+      {mutationError && <ErrorBanner message={mutationError} onRetry={() => setMutationError(undefined)} />}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <StatCard label="Upcoming Coverage" value={scheduledCount} accent="default" />
+        <StatCard label="In Progress" value={activeCount} accent="warning" />
+        <StatCard label="Completed" value={completedCount} accent="success" />
+      </div>
+
+      <div className="rounded-card border border-border bg-card p-5">
+        <h2 className="text-sm font-semibold text-foreground font-kruxt-headline">Create Shift</h2>
+        <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-3">
+          <select value={staffUserId} onChange={(event) => setStaffUserId(event.target.value)} className={INPUT}>
+            <option value="">Select staff member</option>
+            {(staffState.data ?? []).map((staff) => (
+              <option key={staff.userId} value={staff.userId}>{staff.label}</option>
+            ))}
+          </select>
+          <input value={title} onChange={(event) => setTitle(event.target.value)} className={INPUT} placeholder="Shift title" />
+          <input value={shiftRole} onChange={(event) => setShiftRole(event.target.value)} className={INPUT} placeholder="Role, e.g. coach" />
+          <input type="datetime-local" value={startsAt} onChange={(event) => setStartsAt(event.target.value)} className={INPUT} />
+          <input type="datetime-local" value={endsAt} onChange={(event) => setEndsAt(event.target.value)} className={INPUT} />
+          <button
+            onClick={createShift}
+            disabled={creating}
+            className="rounded-button bg-kruxt-accent px-4 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {creating ? "Creating..." : "Create Shift"}
+          </button>
+        </div>
+        <textarea
+          rows={2}
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          className={`${INPUT} mt-3`}
+          placeholder="Coverage notes, handover details, or class responsibilities..."
+        />
+      </div>
+
+      {shifts.length === 0 ? (
+        <EmptyState
+          title="No staff shifts"
+          description="Create the first shift to start planning gym coverage."
+          icon={
+            <svg className="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5A2.25 2.25 0 015.25 5.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5" />
+            </svg>
+          }
+        />
+      ) : (
+        <DataTable columns={columns} data={shifts} keyExtractor={(row) => row.id} />
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/gym-onboarding-form.tsx
+++ b/apps/admin/src/components/gym-onboarding-form.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useAuth } from "@/contexts/auth-context";
+import { useGym } from "@/contexts/gym-context";
+import { createAdminSupabaseClient } from "@/services";
+
+const INPUT =
+  "w-full rounded-lg border border-border bg-kruxt-panel px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-kruxt-accent focus:outline-none focus:ring-1 focus:ring-kruxt-accent/40";
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+export function GymOnboardingForm() {
+  const { user, signOut } = useAuth();
+  const { refresh } = useGym();
+  const [username, setUsername] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [gymName, setGymName] = useState("");
+  const [slugInput, setSlugInput] = useState("");
+  const [slugDirty, setSlugDirty] = useState(false);
+  const [city, setCity] = useState("");
+  const [countryCode, setCountryCode] = useState("IT");
+  const [timezone, setTimezone] = useState("Europe/Rome");
+  const [description, setDescription] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const computedSlug = useMemo(
+    () => (slugDirty ? slugInput : slugify(gymName)),
+    [slugDirty, slugInput, gymName]
+  );
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!user) {
+      setError("You must be signed in.");
+      return;
+    }
+    if (!username.trim() || !displayName.trim() || !gymName.trim() || !computedSlug) {
+      setError("Username, display name, gym name and slug are all required.");
+      return;
+    }
+    if (username.trim().length < 3 || username.trim().length > 24) {
+      setError("Username must be between 3 and 24 characters.");
+      return;
+    }
+    setLoading(true);
+    setError(undefined);
+    try {
+      const supabase = createAdminSupabaseClient();
+
+      // 1. Ensure profile exists (upsert by id)
+      const { error: profileError } = await supabase.from("profiles").upsert(
+        {
+          id: user.id,
+          username: username.trim(),
+          display_name: displayName.trim(),
+        },
+        { onConflict: "id" }
+      );
+      if (profileError) throw profileError;
+
+      // 2. Create the gym
+      const { data: gym, error: gymError } = await supabase
+        .from("gyms")
+        .insert({
+          name: gymName.trim(),
+          slug: computedSlug,
+          owner_user_id: user.id,
+          city: city.trim() || null,
+          country_code: countryCode.trim().toUpperCase().slice(0, 2) || null,
+          timezone: timezone || "UTC",
+          description: description.trim() || null,
+        })
+        .select("id")
+        .single();
+      if (gymError) throw gymError;
+
+      // 3. Link the user as leader/active
+      const { error: memberError } = await supabase
+        .from("gym_memberships")
+        .upsert(
+          {
+            gym_id: gym.id,
+            user_id: user.id,
+            role: "leader",
+            membership_status: "active",
+            started_at: new Date().toISOString(),
+          },
+          { onConflict: "gym_id,user_id" }
+        );
+      if (memberError) throw memberError;
+
+      // 4. Reload gym context; the layout swaps to the dashboard automatically.
+      await refresh();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Failed to create gym";
+      if (msg.includes("duplicate key value") && msg.includes("slug")) {
+        setError("A gym with that URL slug already exists. Pick a different slug.");
+      } else if (msg.includes("duplicate key value") && msg.includes("username")) {
+        setError("That username is already taken. Pick another.");
+      } else {
+        setError(msg);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-kruxt-bg p-6">
+      <div className="w-full max-w-lg rounded-card border border-border bg-card p-8">
+        <h1 className="text-xl font-bold text-foreground font-kruxt-headline">
+          Create your gym
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Set up your gym profile to start managing members, classes, billing, and more.
+        </p>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-kruxt-danger/30 bg-kruxt-danger/10 px-4 py-3 text-sm text-kruxt-danger">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Username *
+              </label>
+              <input
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="edoardo"
+                minLength={3}
+                maxLength={24}
+                className={INPUT}
+                autoComplete="username"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Display name *
+              </label>
+              <input
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="Edoardo Mustarelli"
+                className={INPUT}
+                autoComplete="name"
+              />
+            </div>
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Gym name *
+            </label>
+            <input
+              type="text"
+              value={gymName}
+              onChange={(e) => setGymName(e.target.value)}
+              placeholder="BZone Fitness"
+              className={INPUT}
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              URL slug *
+            </label>
+            <input
+              type="text"
+              value={computedSlug}
+              onChange={(e) => {
+                setSlugInput(e.target.value);
+                setSlugDirty(true);
+              }}
+              placeholder="bzone-fitness"
+              className={INPUT}
+            />
+            <p className="mt-1 text-[10px] text-muted-foreground">
+              Lowercase letters, numbers, and dashes. Used in URLs.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                City
+              </label>
+              <input
+                type="text"
+                value={city}
+                onChange={(e) => setCity(e.target.value)}
+                placeholder="Pavia"
+                className={INPUT}
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Country code
+              </label>
+              <input
+                type="text"
+                value={countryCode}
+                onChange={(e) => setCountryCode(e.target.value.toUpperCase())}
+                maxLength={2}
+                placeholder="IT"
+                className={INPUT}
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Timezone
+            </label>
+            <select
+              value={timezone}
+              onChange={(e) => setTimezone(e.target.value)}
+              className={INPUT}
+            >
+              <option value="Europe/Rome">Europe/Rome (Italy)</option>
+              <option value="Europe/London">Europe/London</option>
+              <option value="Europe/Paris">Europe/Paris</option>
+              <option value="Europe/Madrid">Europe/Madrid</option>
+              <option value="Europe/Berlin">Europe/Berlin</option>
+              <option value="America/New_York">America/New_York</option>
+              <option value="America/Los_Angeles">America/Los_Angeles</option>
+              <option value="UTC">UTC</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Description
+            </label>
+            <textarea
+              rows={2}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Borgo Ticino, Pavia. Functional training, pilates, sala pesi..."
+              className={INPUT}
+            />
+          </div>
+
+          <div className="flex justify-between gap-3 pt-2">
+            <button
+              type="button"
+              onClick={() => signOut()}
+              className="rounded-button border border-border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-kruxt-panel"
+            >
+              Sign out
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded-button bg-kruxt-accent px-5 py-2 text-sm font-semibold text-kruxt-bg transition-opacity hover:opacity-90 disabled:opacity-50"
+            >
+              {loading ? "Creating..." : "Create gym"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/sidebar.tsx
+++ b/apps/admin/src/components/sidebar.tsx
@@ -22,6 +22,7 @@ const navigation: NavGroup[] = [
     items: [
       { label: "Overview", href: "/", icon: "grid" },
       { label: "Members", href: "/members", icon: "users" },
+      { label: "Staff", href: "/staff", icon: "briefcase" },
       { label: "Classes", href: "/classes", icon: "calendar" },
       { label: "Check-ins", href: "/checkins", icon: "check" },
     ],
@@ -73,6 +74,11 @@ const iconMap: Record<string, JSX.Element> = {
   "credit-card": (
     <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25v10.5A2.25 2.25 0 004.5 19.5z" />
+    </svg>
+  ),
+  briefcase: (
+    <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 14.15v4.1A2.25 2.25 0 0118 20.5H6a2.25 2.25 0 01-2.25-2.25v-4.1m16.5 0A2.25 2.25 0 0022.5 11.9V8.25A2.25 2.25 0 0020.25 6H15V4.75A2.25 2.25 0 0012.75 2.5h-1.5A2.25 2.25 0 009 4.75V6H3.75A2.25 2.25 0 001.5 8.25v3.65a2.25 2.25 0 002.25 2.25m16.5 0H3.75m16.5 0v-.25a2.25 2.25 0 00-2.25-2.25H6a2.25 2.25 0 00-2.25 2.25v.25M9 6h6" />
     </svg>
   ),
   link: (

--- a/apps/admin/src/components/status-badge.tsx
+++ b/apps/admin/src/components/status-badge.tsx
@@ -68,6 +68,7 @@ export function statusToVariant(
     case "succeeded":
     case "connected":
     case "approved":
+    case "paid":
       return "success";
     case "pending":
     case "triaged":
@@ -75,6 +76,9 @@ export function statusToVariant(
     case "waiting_approval":
     case "queued":
     case "retry_scheduled":
+    case "open":
+    case "incomplete":
+    case "past_due":
       return "warning";
     case "cancelled":
     case "expired":
@@ -84,11 +88,15 @@ export function statusToVariant(
     case "overdue":
     case "error":
     case "critical":
+    case "unpaid":
+    case "canceled":
       return "danger";
     case "trial":
+    case "trialing":
     case "in_progress":
     case "running":
     case "scheduled":
+    case "draft":
       return "info";
     case "inactive":
     case "suspended":

--- a/apps/admin/src/components/top-bar.tsx
+++ b/apps/admin/src/components/top-bar.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/auth-context";
 import { useGym } from "@/contexts/gym-context";
+import { useServices } from "@/hooks/use-services";
+import type { GymJoinRequestDirectoryItem } from "@/services";
 
 interface TopBarProps {
   sidebarCollapsed: boolean;
@@ -23,20 +26,57 @@ function avatarInitials(email: string | null | undefined): string {
 export function TopBar({ sidebarCollapsed, onMenuToggle }: TopBarProps) {
   const { user, signOut } = useAuth();
   const { gymId, gymName } = useGym();
+  const { gym } = useServices();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const [pendingRequests, setPendingRequests] = useState<GymJoinRequestDirectoryItem[]>([]);
+  const [notificationError, setNotificationError] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const notificationRef = useRef<HTMLDivElement>(null);
 
-  // Close the user menu when clicking outside.
+  // Close floating menus when clicking outside.
   useEffect(() => {
-    if (!menuOpen) return;
+    if (!menuOpen && !notificationsOpen) return;
     const handler = (e: MouseEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setMenuOpen(false);
       }
+      if (notificationRef.current && !notificationRef.current.contains(e.target as Node)) {
+        setNotificationsOpen(false);
+      }
     };
     window.addEventListener("mousedown", handler);
     return () => window.removeEventListener("mousedown", handler);
-  }, [menuOpen]);
+  }, [menuOpen, notificationsOpen]);
+
+  useEffect(() => {
+    if (!gymId) {
+      setPendingRequests([]);
+      return;
+    }
+
+    let active = true;
+
+    async function loadPendingRequests() {
+      try {
+        const requests = await gym.listGymJoinRequests(gymId, "pending");
+        if (!active) return;
+        setPendingRequests(requests);
+        setNotificationError(null);
+      } catch (error) {
+        if (!active) return;
+        setNotificationError(error instanceof Error ? error.message : "Unable to load notifications.");
+      }
+    }
+
+    void loadPendingRequests();
+    const interval = window.setInterval(() => void loadPendingRequests(), 60_000);
+
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+    };
+  }, [gym, gymId]);
 
   const initials = avatarInitials(user?.email);
   const shortGymId = gymId ? gymId.slice(0, 8) : "—";
@@ -85,15 +125,64 @@ export function TopBar({ sidebarCollapsed, onMenuToggle }: TopBarProps) {
         </div>
 
         {/* Notifications */}
-        <button
-          className="relative flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-kruxt-panel hover:text-foreground"
-          aria-label="Notifications"
-        >
-          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
-          </svg>
-          <span className="absolute right-1 top-1 h-2 w-2 rounded-full bg-kruxt-danger" />
-        </button>
+        <div className="relative" ref={notificationRef}>
+          <button
+            className="relative flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-kruxt-panel hover:text-foreground"
+            aria-label="Notifications"
+            aria-expanded={notificationsOpen}
+            onClick={() => setNotificationsOpen((open) => !open)}
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+            </svg>
+            {pendingRequests.length > 0 && (
+              <span className="absolute -right-1 -top-1 min-w-4 rounded-full bg-kruxt-danger px-1 text-[10px] font-bold leading-4 text-white">
+                {pendingRequests.length > 9 ? "9+" : pendingRequests.length}
+              </span>
+            )}
+          </button>
+          {notificationsOpen && (
+            <div className="absolute right-0 top-10 w-80 rounded-card border border-border bg-kruxt-surface p-2 shadow-2xl">
+              <div className="border-b border-border px-3 py-2">
+                <p className="text-xs text-muted-foreground">Notifications</p>
+                <p className="text-sm font-medium text-foreground">
+                  {pendingRequests.length} pending gym access {pendingRequests.length === 1 ? "request" : "requests"}
+                </p>
+              </div>
+              {notificationError ? (
+                <p className="px-3 py-2 text-sm text-kruxt-danger">{notificationError}</p>
+              ) : pendingRequests.length === 0 ? (
+                <p className="px-3 py-2 text-sm text-muted-foreground">No pending access requests.</p>
+              ) : (
+                <div className="max-h-72 overflow-y-auto py-1">
+                  {pendingRequests.slice(0, 5).map((request) => (
+                    <Link
+                      key={request.id}
+                      href="/members"
+                      onClick={() => setNotificationsOpen(false)}
+                      className="block rounded-md px-3 py-2 text-sm transition-colors hover:bg-kruxt-panel"
+                    >
+                      <span className="block font-medium text-foreground">
+                        {request.profile?.label ?? request.userId.slice(0, 8)}
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        {request.source === "invite_code" ? "Invite code" : "Public request"}
+                        {request.membershipPlanName ? ` / ${request.membershipPlanName}` : ""}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              )}
+              <Link
+                href="/members"
+                onClick={() => setNotificationsOpen(false)}
+                className="mt-1 block rounded-md px-3 py-2 text-sm font-medium text-kruxt-accent transition-colors hover:bg-kruxt-panel"
+              >
+                Open approvals
+              </Link>
+            </div>
+          )}
+        </div>
 
         {/* User avatar + dropdown */}
         <div className="relative" ref={menuRef}>

--- a/apps/admin/src/services/b2b-ops-service.ts
+++ b/apps/admin/src/services/b2b-ops-service.ts
@@ -275,6 +275,76 @@ type GymMembershipLinkRow = {
   user_id: string;
 };
 
+type ProfileRow = {
+  id: string;
+  display_name: string | null;
+  username: string | null;
+};
+
+const MANUAL_BILLING_FEATURE_KEY = "manual_billing";
+
+export interface BillingProfileSummary {
+  userId: string;
+  displayName: string;
+  username: string;
+  label: string;
+}
+
+export interface MemberSubscriptionDirectoryItem extends MemberSubscription {
+  profile?: BillingProfileSummary;
+  membershipPlan?: GymMembershipPlan | null;
+}
+
+export interface RecordManualInvoicePaymentInput {
+  invoiceId: string;
+  amountCents?: number | null;
+  paymentMethodType?: string | null;
+  reference?: string | null;
+  note?: string | null;
+  capturedAt?: string | null;
+}
+
+export interface ManualBillingSettings {
+  instructions: string;
+  bankAccountLabel: string;
+  accountHolder: string;
+  iban: string;
+  paymentReferenceFormat: string;
+  cashDeskNote: string;
+  externalPaymentUrl: string;
+}
+
+const emptyManualBillingSettings: ManualBillingSettings = {
+  instructions: "",
+  bankAccountLabel: "",
+  accountHolder: "",
+  iban: "",
+  paymentReferenceFormat: "",
+  cashDeskNote: "",
+  externalPaymentUrl: ""
+};
+
+function compactText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeManualBillingSettings(config: unknown): ManualBillingSettings {
+  const row =
+    config && typeof config === "object" && !Array.isArray(config)
+      ? (config as Record<string, unknown>)
+      : {};
+
+  return {
+    instructions: compactText(row.instructions),
+    bankAccountLabel: compactText(row.bankAccountLabel),
+    accountHolder: compactText(row.accountHolder),
+    iban: compactText(row.iban),
+    paymentReferenceFormat: compactText(row.paymentReferenceFormat),
+    cashDeskNote: compactText(row.cashDeskNote),
+    externalPaymentUrl: compactText(row.externalPaymentUrl)
+  };
+}
+
 function mapPlan(row: GymMembershipPlanRow): GymMembershipPlan {
   return {
     id: row.id,
@@ -291,6 +361,20 @@ function mapPlan(row: GymMembershipPlanRow): GymMembershipPlan {
     isActive: row.is_active,
     createdAt: row.created_at,
     updatedAt: row.updated_at
+  };
+}
+
+function profileLabel(profile?: ProfileRow | null): BillingProfileSummary | undefined {
+  if (!profile) return undefined;
+
+  const displayName = profile.display_name?.trim() || profile.username?.trim() || profile.id.slice(0, 8);
+  const username = profile.username?.trim() || "";
+
+  return {
+    userId: profile.id,
+    displayName,
+    username,
+    label: username ? `${displayName} (@${username})` : displayName
   };
 }
 
@@ -1259,6 +1343,50 @@ export class B2BOpsService {
     return mapAccessLog(data as AccessLogRow);
   }
 
+  async getManualBillingSettings(gymId: string): Promise<ManualBillingSettings> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data, error } = await this.supabase
+      .from("gym_feature_settings")
+      .select("config")
+      .eq("gym_id", gymId)
+      .eq("feature_key", MANUAL_BILLING_FEATURE_KEY)
+      .maybeSingle();
+
+    throwIfAdminError(error, "ADMIN_MANUAL_BILLING_SETTINGS_READ_FAILED", "Unable to load billing instructions.");
+
+    return data ? normalizeManualBillingSettings((data as { config?: unknown }).config) : emptyManualBillingSettings;
+  }
+
+  async upsertManualBillingSettings(
+    gymId: string,
+    input: ManualBillingSettings
+  ): Promise<ManualBillingSettings> {
+    const staff = await this.access.requireGymStaff(gymId);
+    const config = normalizeManualBillingSettings(input);
+
+    const { data, error } = await this.supabase
+      .from("gym_feature_settings")
+      .upsert(
+        {
+          gym_id: gymId,
+          feature_key: MANUAL_BILLING_FEATURE_KEY,
+          enabled: true,
+          rollout_percentage: 100,
+          config,
+          note: "Manual payment instructions shown to members with open invoices.",
+          updated_by: staff.user_id
+        },
+        { onConflict: "gym_id,feature_key" }
+      )
+      .select("config")
+      .single();
+
+    throwIfAdminError(error, "ADMIN_MANUAL_BILLING_SETTINGS_SAVE_FAILED", "Unable to save billing instructions.");
+
+    return normalizeManualBillingSettings((data as { config?: unknown }).config);
+  }
+
   async listMemberSubscriptions(gymId: string, limit = 200): Promise<MemberSubscription[]> {
     await this.access.requireGymStaff(gymId);
 
@@ -1272,6 +1400,62 @@ export class B2BOpsService {
     throwIfAdminError(error, "ADMIN_SUBSCRIPTIONS_READ_FAILED", "Unable to load member subscriptions.");
 
     return ((data as MemberSubscriptionRow[]) ?? []).map(mapSubscription);
+  }
+
+  async listMemberSubscriptionDirectory(gymId: string, limit = 200): Promise<MemberSubscriptionDirectoryItem[]> {
+    const subscriptions = await this.listMemberSubscriptions(gymId, limit);
+
+    if (subscriptions.length === 0) {
+      return [];
+    }
+
+    const userIds = Array.from(new Set(subscriptions.map((subscription) => subscription.userId)));
+    const planIds = Array.from(
+      new Set(
+        subscriptions
+          .map((subscription) => subscription.membershipPlanId)
+          .filter((value): value is string => Boolean(value))
+      )
+    );
+
+    const [profilesResponse, plansResponse] = await Promise.all([
+      userIds.length > 0
+        ? this.supabase.from("profiles").select("id,display_name,username").in("id", userIds)
+        : Promise.resolve({ data: [], error: null }),
+      planIds.length > 0
+        ? this.supabase.from("gym_membership_plans").select("*").eq("gym_id", gymId).in("id", planIds)
+        : Promise.resolve({ data: [], error: null })
+    ]);
+
+    throwIfAdminError(
+      profilesResponse.error,
+      "ADMIN_SUBSCRIPTION_PROFILES_READ_FAILED",
+      "Unable to load subscription member profiles."
+    );
+    throwIfAdminError(
+      plansResponse.error,
+      "ADMIN_SUBSCRIPTION_PLANS_READ_FAILED",
+      "Unable to load subscription plans."
+    );
+
+    const profileMap = new Map<string, BillingProfileSummary>();
+    for (const profile of ((profilesResponse.data as ProfileRow[]) ?? [])) {
+      const mapped = profileLabel(profile);
+      if (mapped) {
+        profileMap.set(profile.id, mapped);
+      }
+    }
+
+    const planMap = new Map<string, GymMembershipPlan>();
+    for (const plan of ((plansResponse.data as GymMembershipPlanRow[]) ?? [])) {
+      planMap.set(plan.id, mapPlan(plan));
+    }
+
+    return subscriptions.map((subscription) => ({
+      ...subscription,
+      profile: profileMap.get(subscription.userId),
+      membershipPlan: subscription.membershipPlanId ? planMap.get(subscription.membershipPlanId) ?? null : null
+    }));
   }
 
   async upsertMemberSubscription(
@@ -1363,6 +1547,35 @@ export class B2BOpsService {
     throwIfAdminError(error, "ADMIN_INVOICE_UPDATE_FAILED", "Unable to update invoice.");
 
     return mapInvoice(data as InvoiceRow);
+  }
+
+  async recordManualInvoicePayment(
+    gymId: string,
+    input: RecordManualInvoicePaymentInput
+  ): Promise<PaymentTransaction> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data: paymentId, error: rpcError } = await this.supabase.rpc("record_manual_invoice_payment", {
+      p_invoice_id: input.invoiceId,
+      p_amount_cents: input.amountCents ?? null,
+      p_payment_method_type: input.paymentMethodType ?? "manual",
+      p_reference: input.reference ?? null,
+      p_note: input.note ?? null,
+      p_captured_at: input.capturedAt ?? new Date().toISOString()
+    });
+
+    throwIfAdminError(rpcError, "ADMIN_MANUAL_PAYMENT_CREATE_FAILED", "Unable to record manual payment.");
+
+    const { data, error } = await this.supabase
+      .from("payment_transactions")
+      .select("*")
+      .eq("id", String(paymentId))
+      .eq("gym_id", gymId)
+      .single();
+
+    throwIfAdminError(error, "ADMIN_MANUAL_PAYMENT_READ_FAILED", "Unable to load recorded payment.");
+
+    return mapPayment(data as PaymentTransactionRow);
   }
 
   async listPaymentTransactions(gymId: string, limit = 200): Promise<PaymentTransaction[]> {

--- a/apps/admin/src/services/gym-admin-service.ts
+++ b/apps/admin/src/services/gym-admin-service.ts
@@ -1,13 +1,27 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
+  CreateGymInviteCodeInput,
+  CreateMemberWorkoutPlanInput,
+  CreateStaffShiftInput,
   ConsentRecord,
+  GymInviteCode,
+  GymJoinRequest,
+  GymJoinRequestSource,
+  GymJoinRequestStatus,
   GymMembership,
   GymOpsSummary,
   GymRole,
   IncidentStatus,
+  MemberWorkoutPlan,
+  MemberWorkoutPlanStatus,
   MembershipStatus,
   PolicyVersion,
-  PrivacyRequestStatus
+  PrivacyRequestStatus,
+  ReviewGymJoinRequestInput,
+  StaffShift,
+  StaffShiftStatus,
+  UpdateGymInviteCodeInput,
+  UpdateStaffShiftInput
 } from "@kruxt/types";
 
 import { KruxtAdminError, throwIfAdminError } from "./errors";
@@ -19,17 +33,25 @@ type MembershipRow = {
   id: string;
   gym_id: string;
   user_id: string;
+  coach_user_id?: string | null;
   role: GymRole;
   membership_status: MembershipStatus;
   membership_plan_id: string | null;
   started_at: string | null;
   ends_at: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
 };
 
 type ProfileRow = {
   id: string;
-  display_name: string;
-  username: string;
+  display_name: string | null;
+  username: string | null;
+};
+
+type MembershipPlanRow = {
+  id: string;
+  name: string;
 };
 
 type ConsentRow = {
@@ -119,6 +141,73 @@ type GymClassRow = {
   starts_at: string;
   ends_at: string;
   capacity: number;
+};
+
+type StaffShiftRow = {
+  id: string;
+  gym_id: string;
+  staff_user_id: string;
+  created_by: string | null;
+  title: string;
+  shift_role: string | null;
+  starts_at: string;
+  ends_at: string;
+  status: StaffShiftStatus;
+  hourly_rate_cents: number | null;
+  notes: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+type MemberWorkoutPlanRow = {
+  id: string;
+  gym_id: string;
+  member_user_id: string;
+  coach_user_id: string | null;
+  title: string;
+  goal: string | null;
+  status: MemberWorkoutPlanStatus;
+  starts_at: string | null;
+  ends_at: string | null;
+  plan_json: Record<string, unknown>;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type GymInviteCodeRow = {
+  id: string;
+  gym_id: string;
+  code: string;
+  label: string | null;
+  role: GymRole;
+  membership_status: MembershipStatus;
+  membership_plan_id: string | null;
+  max_redemptions: number | null;
+  redeemed_count: number;
+  expires_at: string | null;
+  is_active: boolean;
+  created_by: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+type GymJoinRequestRow = {
+  id: string;
+  gym_id: string;
+  user_id: string;
+  requested_membership_plan_id: string | null;
+  source: GymJoinRequestSource;
+  invite_code_id: string | null;
+  status: GymJoinRequestStatus;
+  note: string | null;
+  staff_note: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+  updated_at: string;
 };
 
 type SecurityIncidentRow = {
@@ -212,16 +301,127 @@ export interface StaffProfileOption {
   label: string;
 }
 
+export interface MemberProfileSummary {
+  userId: string;
+  displayName: string;
+  username: string;
+  label: string;
+}
+
+export interface GymMemberDirectoryItem extends GymMembership {
+  profile?: MemberProfileSummary;
+  coachProfile?: MemberProfileSummary | null;
+  membershipPlanName?: string | null;
+  latestWorkoutPlan?: MemberWorkoutPlan | null;
+}
+
+export interface GymJoinRequestDirectoryItem extends GymJoinRequest {
+  profile?: MemberProfileSummary;
+  membershipPlanName?: string | null;
+  inviteLabel?: string | null;
+}
+
 function mapMembership(row: MembershipRow): GymMembership {
   return {
     id: row.id,
     gymId: row.gym_id,
     userId: row.user_id,
+    coachUserId: row.coach_user_id ?? null,
     role: row.role,
     membershipStatus: row.membership_status,
     membershipPlanId: row.membership_plan_id,
     startedAt: row.started_at,
     endsAt: row.ends_at
+  };
+}
+
+function profileLabel(profile?: ProfileRow | null): MemberProfileSummary | undefined {
+  if (!profile) {
+    return undefined;
+  }
+
+  const displayName = profile.display_name?.trim() || "Unnamed member";
+  const username = profile.username?.trim() || "";
+  return {
+    userId: profile.id,
+    displayName,
+    username,
+    label: username ? `${displayName} (@${username})` : displayName
+  };
+}
+
+function mapStaffShift(row: StaffShiftRow): StaffShift {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    staffUserId: row.staff_user_id,
+    createdBy: row.created_by,
+    title: row.title,
+    shiftRole: row.shift_role,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    status: row.status,
+    hourlyRateCents: row.hourly_rate_cents,
+    notes: row.notes,
+    metadata: row.metadata ?? {},
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapMemberWorkoutPlan(row: MemberWorkoutPlanRow): MemberWorkoutPlan {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    memberUserId: row.member_user_id,
+    coachUserId: row.coach_user_id,
+    title: row.title,
+    goal: row.goal,
+    status: row.status,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    planJson: row.plan_json ?? {},
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapGymInviteCode(row: GymInviteCodeRow): GymInviteCode {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    code: row.code,
+    label: row.label,
+    role: row.role,
+    membershipStatus: row.membership_status,
+    membershipPlanId: row.membership_plan_id,
+    maxRedemptions: row.max_redemptions,
+    redeemedCount: row.redeemed_count,
+    expiresAt: row.expires_at,
+    isActive: row.is_active,
+    createdBy: row.created_by,
+    metadata: row.metadata ?? {},
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function mapGymJoinRequest(row: GymJoinRequestRow): GymJoinRequest {
+  return {
+    id: row.id,
+    gymId: row.gym_id,
+    userId: row.user_id,
+    requestedMembershipPlanId: row.requested_membership_plan_id,
+    source: row.source,
+    inviteCodeId: row.invite_code_id,
+    status: row.status,
+    note: row.note,
+    staffNote: row.staff_note,
+    reviewedBy: row.reviewed_by,
+    reviewedAt: row.reviewed_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
   };
 }
 
@@ -266,6 +466,23 @@ function mapPolicyVersion(row: PolicyVersionRow): PolicyVersion {
   };
 }
 
+function generateInviteCode(): string {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  const bytes = new Uint8Array(10);
+  globalThis.crypto?.getRandomValues(bytes);
+
+  const chars = Array.from(bytes, (byte) => alphabet[byte % alphabet.length]);
+  return `KRUXT-${chars.slice(0, 5).join("")}-${chars.slice(5).join("")}`;
+}
+
+function normalizeInviteCode(code: string): string {
+  return code
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9-]/g, "")
+    .slice(0, 64);
+}
+
 export class GymAdminService {
   private readonly access: StaffAccessService;
 
@@ -285,6 +502,90 @@ export class GymAdminService {
     throwIfAdminError(error, "ADMIN_MEMBERSHIP_LIST_FAILED", "Unable to list gym memberships.");
 
     return (data as MembershipRow[]).map(mapMembership);
+  }
+
+  async listGymMemberDirectory(gymId: string): Promise<GymMemberDirectoryItem[]> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data, error } = await this.supabase
+      .from("gym_memberships")
+      .select("*")
+      .eq("gym_id", gymId)
+      .order("created_at", { ascending: false });
+
+    throwIfAdminError(error, "ADMIN_MEMBERSHIP_LIST_FAILED", "Unable to list gym memberships.");
+
+    const rows = (data as MembershipRow[]) ?? [];
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const userIds = Array.from(
+      new Set(
+        rows
+          .flatMap((row) => [row.user_id, row.coach_user_id])
+          .filter((value): value is string => Boolean(value))
+      )
+    );
+    const planIds = Array.from(
+      new Set(rows.map((row) => row.membership_plan_id).filter((value): value is string => Boolean(value)))
+    );
+
+    const profileMap = new Map<string, MemberProfileSummary>();
+    if (userIds.length > 0) {
+      const { data: profiles, error: profileError } = await this.supabase
+        .from("profiles")
+        .select("id,display_name,username")
+        .in("id", userIds);
+
+      throwIfAdminError(profileError, "ADMIN_PROFILE_LIST_FAILED", "Unable to load member profiles.");
+
+      for (const profile of (profiles as ProfileRow[]) ?? []) {
+        const mapped = profileLabel(profile);
+        if (mapped) {
+          profileMap.set(mapped.userId, mapped);
+        }
+      }
+    }
+
+    const planMap = new Map<string, string>();
+    if (planIds.length > 0) {
+      const { data: plans, error: planError } = await this.supabase
+        .from("gym_membership_plans")
+        .select("id,name")
+        .eq("gym_id", gymId)
+        .in("id", planIds);
+
+      throwIfAdminError(planError, "ADMIN_PLAN_LIST_FAILED", "Unable to load membership plan labels.");
+
+      for (const plan of (plans as MembershipPlanRow[]) ?? []) {
+        planMap.set(plan.id, plan.name);
+      }
+    }
+
+    const latestPlanMap = new Map<string, MemberWorkoutPlan>();
+    const { data: workoutPlans, error: workoutPlanError } = await this.supabase
+      .from("gym_member_workout_plans")
+      .select("*")
+      .eq("gym_id", gymId)
+      .in("member_user_id", rows.map((row) => row.user_id))
+      .order("updated_at", { ascending: false });
+
+    if (!workoutPlanError) {
+      for (const plan of (workoutPlans as MemberWorkoutPlanRow[]) ?? []) {
+        if (!latestPlanMap.has(plan.member_user_id)) {
+          latestPlanMap.set(plan.member_user_id, mapMemberWorkoutPlan(plan));
+        }
+      }
+    }
+
+    return rows.map((row) => ({
+      ...mapMembership(row),
+      profile: profileMap.get(row.user_id),
+      coachProfile: row.coach_user_id ? profileMap.get(row.coach_user_id) ?? null : null,
+      membershipPlanName: row.membership_plan_id ? planMap.get(row.membership_plan_id) ?? null : null,
+      latestWorkoutPlan: latestPlanMap.get(row.user_id) ?? null
+    }));
   }
 
   async listPendingMemberships(gymId: string): Promise<GymMembership[]> {
@@ -334,6 +635,26 @@ export class GymAdminService {
       .single();
 
     throwIfAdminError(error, "ADMIN_ROLE_ASSIGN_FAILED", "Unable to assign gym role.");
+
+    return mapMembership(data as MembershipRow);
+  }
+
+  async assignMembershipCoach(
+    gymId: string,
+    membershipId: string,
+    coachUserId: string | null
+  ): Promise<GymMembership> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data, error } = await this.supabase
+      .from("gym_memberships")
+      .update({ coach_user_id: coachUserId?.trim() || null })
+      .eq("id", membershipId)
+      .eq("gym_id", gymId)
+      .select("*")
+      .single();
+
+    throwIfAdminError(error, "ADMIN_COACH_ASSIGN_FAILED", "Unable to assign personal trainer.");
 
     return mapMembership(data as MembershipRow);
   }
@@ -401,12 +722,360 @@ export class GymAdminService {
     const { data, error } = await query;
     throwIfAdminError(error, "ADMIN_PROFILE_SEARCH_FAILED", "Unable to search member profiles.");
 
-    return ((data as ProfileRow[]) ?? []).map((profile) => ({
-      userId: profile.id,
-      displayName: profile.display_name,
-      username: profile.username,
-      label: `${profile.display_name} (@${profile.username})`
+    return ((data as ProfileRow[]) ?? []).flatMap((profile) => {
+      const mapped = profileLabel(profile);
+      return mapped ? [mapped] : [];
+    });
+  }
+
+  async listGymInviteCodes(gymId: string): Promise<GymInviteCode[]> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data, error } = await this.supabase
+      .from("gym_invite_codes")
+      .select("*")
+      .eq("gym_id", gymId)
+      .order("created_at", { ascending: false });
+
+    throwIfAdminError(error, "ADMIN_INVITE_CODE_LIST_FAILED", "Unable to load invite codes.");
+
+    return ((data as GymInviteCodeRow[]) ?? []).map(mapGymInviteCode);
+  }
+
+  async createGymInviteCode(gymId: string, input: CreateGymInviteCodeInput = {}): Promise<GymInviteCode> {
+    const staff = await this.access.requireGymStaff(gymId);
+    const code = normalizeInviteCode(input.code || generateInviteCode());
+
+    if (code.length < 4) {
+      throw new KruxtAdminError("ADMIN_INVITE_CODE_INVALID", "Invite code must be at least 4 characters.");
+    }
+
+    if (input.membershipPlanId) {
+      const { data: plan, error: planError } = await this.supabase
+        .from("gym_membership_plans")
+        .select("id")
+        .eq("id", input.membershipPlanId)
+        .eq("gym_id", gymId)
+        .eq("is_active", true)
+        .maybeSingle();
+
+      throwIfAdminError(planError, "ADMIN_INVITE_PLAN_READ_FAILED", "Unable to validate invite membership plan.");
+      if (!plan) {
+        throw new KruxtAdminError("ADMIN_INVITE_PLAN_INVALID", "Invite membership plan must belong to this gym.");
+      }
+    }
+
+    const { data, error } = await this.supabase
+      .from("gym_invite_codes")
+      .insert({
+        gym_id: gymId,
+        code,
+        label: input.label?.trim() || null,
+        role: input.role ?? "member",
+        membership_status: input.membershipStatus ?? "active",
+        membership_plan_id: input.membershipPlanId ?? null,
+        max_redemptions: input.maxRedemptions ?? null,
+        expires_at: input.expiresAt ?? null,
+        is_active: true,
+        created_by: staff.user_id,
+        metadata: input.metadata ?? {}
+      })
+      .select("*")
+      .single();
+
+    throwIfAdminError(error, "ADMIN_INVITE_CODE_CREATE_FAILED", "Unable to create invite code.");
+
+    return mapGymInviteCode(data as GymInviteCodeRow);
+  }
+
+  async updateGymInviteCode(
+    gymId: string,
+    inviteCodeId: string,
+    input: UpdateGymInviteCodeInput
+  ): Promise<GymInviteCode> {
+    await this.access.requireGymStaff(gymId);
+
+    const payload: Record<string, unknown> = {};
+    if (input.code !== undefined) payload.code = normalizeInviteCode(input.code);
+    if (input.label !== undefined) payload.label = input.label?.trim() || null;
+    if (input.role !== undefined) payload.role = input.role;
+    if (input.membershipStatus !== undefined) payload.membership_status = input.membershipStatus;
+    if (input.membershipPlanId !== undefined) payload.membership_plan_id = input.membershipPlanId;
+    if (input.maxRedemptions !== undefined) payload.max_redemptions = input.maxRedemptions;
+    if (input.expiresAt !== undefined) payload.expires_at = input.expiresAt;
+    if (input.isActive !== undefined) payload.is_active = input.isActive;
+    if (input.metadata !== undefined) payload.metadata = input.metadata;
+
+    const { data, error } = await this.supabase
+      .from("gym_invite_codes")
+      .update(payload)
+      .eq("id", inviteCodeId)
+      .eq("gym_id", gymId)
+      .select("*")
+      .single();
+
+    throwIfAdminError(error, "ADMIN_INVITE_CODE_UPDATE_FAILED", "Unable to update invite code.");
+
+    return mapGymInviteCode(data as GymInviteCodeRow);
+  }
+
+  async listGymJoinRequests(
+    gymId: string,
+    status: GymJoinRequestStatus | "all" = "pending"
+  ): Promise<GymJoinRequestDirectoryItem[]> {
+    await this.access.requireGymStaff(gymId);
+
+    let query = this.supabase
+      .from("gym_join_requests")
+      .select("*")
+      .eq("gym_id", gymId)
+      .order("created_at", { ascending: false })
+      .limit(100);
+
+    if (status !== "all") {
+      query = query.eq("status", status);
+    }
+
+    const { data, error } = await query;
+    throwIfAdminError(error, "ADMIN_JOIN_REQUEST_LIST_FAILED", "Unable to load gym join requests.");
+
+    const rows = ((data as GymJoinRequestRow[]) ?? []).map(mapGymJoinRequest);
+    if (rows.length === 0) {
+      return [];
+    }
+
+    const userIds = Array.from(new Set(rows.map((row) => row.userId)));
+    const planIds = Array.from(
+      new Set(rows.map((row) => row.requestedMembershipPlanId).filter((value): value is string => Boolean(value)))
+    );
+    const inviteIds = Array.from(
+      new Set(rows.map((row) => row.inviteCodeId).filter((value): value is string => Boolean(value)))
+    );
+
+    const profileMap = new Map<string, MemberProfileSummary>();
+    const { data: profiles, error: profileError } = await this.supabase
+      .from("profiles")
+      .select("id,display_name,username")
+      .in("id", userIds);
+
+    throwIfAdminError(profileError, "ADMIN_JOIN_REQUEST_PROFILE_LIST_FAILED", "Unable to load join request profiles.");
+
+    for (const profile of (profiles as ProfileRow[]) ?? []) {
+      const mapped = profileLabel(profile);
+      if (mapped) {
+        profileMap.set(mapped.userId, mapped);
+      }
+    }
+
+    const planMap = new Map<string, string>();
+    if (planIds.length > 0) {
+      const { data: plans, error: planError } = await this.supabase
+        .from("gym_membership_plans")
+        .select("id,name")
+        .eq("gym_id", gymId)
+        .in("id", planIds);
+
+      throwIfAdminError(planError, "ADMIN_JOIN_REQUEST_PLAN_LIST_FAILED", "Unable to load join request plans.");
+
+      for (const plan of (plans as MembershipPlanRow[]) ?? []) {
+        planMap.set(plan.id, plan.name);
+      }
+    }
+
+    const inviteMap = new Map<string, string>();
+    if (inviteIds.length > 0) {
+      const { data: invites, error: inviteError } = await this.supabase
+        .from("gym_invite_codes")
+        .select("id,label,code")
+        .eq("gym_id", gymId)
+        .in("id", inviteIds);
+
+      throwIfAdminError(inviteError, "ADMIN_JOIN_REQUEST_INVITE_LIST_FAILED", "Unable to load join request invites.");
+
+      for (const invite of (invites as Array<{ id: string; label: string | null; code: string }>) ?? []) {
+        inviteMap.set(invite.id, invite.label || invite.code);
+      }
+    }
+
+    return rows.map((row) => ({
+      ...row,
+      profile: profileMap.get(row.userId),
+      membershipPlanName: row.requestedMembershipPlanId ? planMap.get(row.requestedMembershipPlanId) ?? null : null,
+      inviteLabel: row.inviteCodeId ? inviteMap.get(row.inviteCodeId) ?? null : null
     }));
+  }
+
+  async reviewGymJoinRequest(gymId: string, input: ReviewGymJoinRequestInput): Promise<string> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data, error } = await this.supabase.rpc("review_gym_join_request", {
+      p_request_id: input.requestId,
+      p_next_status: input.nextStatus,
+      p_staff_note: input.staffNote ?? null
+    });
+
+    throwIfAdminError(error, "ADMIN_JOIN_REQUEST_REVIEW_FAILED", "Unable to review join request.");
+
+    return String(data);
+  }
+
+  async listStaffProfileOptions(gymId: string): Promise<StaffProfileOption[]> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data: memberships, error: membershipError } = await this.supabase
+      .from("gym_memberships")
+      .select("user_id")
+      .eq("gym_id", gymId)
+      .in("membership_status", ["trial", "active"])
+      .in("role", ["leader", "officer", "coach"]);
+
+    throwIfAdminError(membershipError, "ADMIN_STAFF_LIST_FAILED", "Unable to load staff members.");
+
+    const userIds = Array.from(new Set(((memberships as Array<{ user_id: string }>) ?? []).map((row) => row.user_id)));
+    if (userIds.length === 0) {
+      return [];
+    }
+
+    const { data: profiles, error: profileError } = await this.supabase
+      .from("profiles")
+      .select("id,display_name,username")
+      .in("id", userIds);
+
+    throwIfAdminError(profileError, "ADMIN_STAFF_PROFILE_LIST_FAILED", "Unable to load staff profiles.");
+
+    return ((profiles as ProfileRow[]) ?? [])
+      .flatMap((profile) => {
+        const mapped = profileLabel(profile);
+        return mapped ? [mapped] : [];
+      })
+      .sort((left, right) => left.label.localeCompare(right.label));
+  }
+
+  async listMemberWorkoutPlans(gymId: string, memberUserId: string): Promise<MemberWorkoutPlan[]> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data, error } = await this.supabase
+      .from("gym_member_workout_plans")
+      .select("*")
+      .eq("gym_id", gymId)
+      .eq("member_user_id", memberUserId)
+      .order("updated_at", { ascending: false })
+      .limit(20);
+
+    throwIfAdminError(error, "ADMIN_WORKOUT_PLAN_LIST_FAILED", "Unable to load workout plans.");
+
+    return ((data as MemberWorkoutPlanRow[]) ?? []).map(mapMemberWorkoutPlan);
+  }
+
+  async createMemberWorkoutPlan(
+    gymId: string,
+    input: CreateMemberWorkoutPlanInput
+  ): Promise<MemberWorkoutPlan> {
+    const staff = await this.access.requireGymStaff(gymId);
+
+    const title = input.title.trim();
+    if (!title) {
+      throw new KruxtAdminError("ADMIN_WORKOUT_PLAN_TITLE_REQUIRED", "Workout plan title is required.");
+    }
+
+    const { data, error } = await this.supabase
+      .from("gym_member_workout_plans")
+      .insert({
+        gym_id: gymId,
+        member_user_id: input.memberUserId,
+        coach_user_id: input.coachUserId ?? null,
+        title,
+        goal: input.goal?.trim() || null,
+        status: input.status ?? "active",
+        starts_at: input.startsAt ?? null,
+        ends_at: input.endsAt ?? null,
+        plan_json: input.planJson ?? {},
+        created_by: staff.user_id
+      })
+      .select("*")
+      .single();
+
+    throwIfAdminError(error, "ADMIN_WORKOUT_PLAN_CREATE_FAILED", "Unable to create workout plan.");
+
+    return mapMemberWorkoutPlan(data as MemberWorkoutPlanRow);
+  }
+
+  async listStaffShifts(gymId: string, limit = 100): Promise<StaffShift[]> {
+    await this.access.requireGymStaff(gymId);
+
+    const { data, error } = await this.supabase
+      .from("staff_shifts")
+      .select("*")
+      .eq("gym_id", gymId)
+      .order("starts_at", { ascending: true })
+      .limit(Math.min(Math.max(limit, 1), 250));
+
+    throwIfAdminError(error, "ADMIN_STAFF_SHIFT_LIST_FAILED", "Unable to load staff schedule.");
+
+    return ((data as StaffShiftRow[]) ?? []).map(mapStaffShift);
+  }
+
+  async createStaffShift(gymId: string, input: CreateStaffShiftInput): Promise<StaffShift> {
+    const staff = await this.access.requireGymStaff(gymId);
+
+    if (!input.staffUserId.trim()) {
+      throw new KruxtAdminError("ADMIN_STAFF_SHIFT_USER_REQUIRED", "Staff member is required.");
+    }
+
+    const startsAt = new Date(input.startsAt);
+    const endsAt = new Date(input.endsAt);
+    if (!Number.isFinite(startsAt.valueOf()) || !Number.isFinite(endsAt.valueOf()) || endsAt <= startsAt) {
+      throw new KruxtAdminError("ADMIN_STAFF_SHIFT_TIME_INVALID", "Shift end must be after shift start.");
+    }
+
+    const { data, error } = await this.supabase
+      .from("staff_shifts")
+      .insert({
+        gym_id: gymId,
+        staff_user_id: input.staffUserId,
+        created_by: staff.user_id,
+        title: input.title?.trim() || "Shift",
+        shift_role: input.shiftRole?.trim() || null,
+        starts_at: input.startsAt,
+        ends_at: input.endsAt,
+        status: input.status ?? "scheduled",
+        hourly_rate_cents: input.hourlyRateCents ?? null,
+        notes: input.notes?.trim() || null,
+        metadata: input.metadata ?? {}
+      })
+      .select("*")
+      .single();
+
+    throwIfAdminError(error, "ADMIN_STAFF_SHIFT_CREATE_FAILED", "Unable to create staff shift.");
+
+    return mapStaffShift(data as StaffShiftRow);
+  }
+
+  async updateStaffShift(gymId: string, shiftId: string, input: UpdateStaffShiftInput): Promise<StaffShift> {
+    await this.access.requireGymStaff(gymId);
+
+    const payload: Record<string, unknown> = {};
+    if (input.staffUserId !== undefined) payload.staff_user_id = input.staffUserId;
+    if (input.title !== undefined) payload.title = input.title.trim() || "Shift";
+    if (input.shiftRole !== undefined) payload.shift_role = input.shiftRole?.trim() || null;
+    if (input.startsAt !== undefined) payload.starts_at = input.startsAt;
+    if (input.endsAt !== undefined) payload.ends_at = input.endsAt;
+    if (input.status !== undefined) payload.status = input.status;
+    if (input.hourlyRateCents !== undefined) payload.hourly_rate_cents = input.hourlyRateCents;
+    if (input.notes !== undefined) payload.notes = input.notes?.trim() || null;
+    if (input.metadata !== undefined) payload.metadata = input.metadata;
+
+    const { data, error } = await this.supabase
+      .from("staff_shifts")
+      .update(payload)
+      .eq("id", shiftId)
+      .eq("gym_id", gymId)
+      .select("*")
+      .single();
+
+    throwIfAdminError(error, "ADMIN_STAFF_SHIFT_UPDATE_FAILED", "Unable to update staff shift.");
+
+    return mapStaffShift(data as StaffShiftRow);
   }
 
   async getGymOpsSummary(gymId: string): Promise<GymOpsSummary> {

--- a/apps/admin/src/services/index.ts
+++ b/apps/admin/src/services/index.ts
@@ -6,3 +6,4 @@ export * from "./b2b-ops-service";
 export * from "./integration-monitor-service";
 export * from "./customization-support-service";
 export * from "./platform-control-plane-service";
+export * from "./seed-bzone";

--- a/apps/admin/src/services/seed-bzone.ts
+++ b/apps/admin/src/services/seed-bzone.ts
@@ -1,0 +1,253 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Seeds a gym with realistic demo data based on BZone Fitness (Pavia, Italy).
+ * Owner: Tommaso Di Genua. Source: bzonefitness.it
+ *
+ * Idempotent for plans + waiver (unique constraints + onConflict). Classes are
+ * skipped if any already exist for the gym to avoid duplicating the schedule.
+ */
+
+export interface SeedResult {
+  plansUpserted: number;
+  classesCreated: number;
+  classesSkipped: boolean;
+  waiverUpserted: boolean;
+  billingSettingsUpserted: boolean;
+}
+
+interface PlanSeed {
+  name: string;
+  billing_cycle: "monthly" | "quarterly" | "yearly" | "dropin";
+  price_cents: number;
+  currency: string;
+  cancel_policy: string;
+}
+
+const BZONE_PLANS: PlanSeed[] = [
+  {
+    name: "Action Light",
+    billing_cycle: "monthly",
+    price_cents: 5000,
+    currency: "EUR",
+    cancel_policy: "Accesso illimitato Sala Pesi e Cardio.",
+  },
+  {
+    name: "Action Medium",
+    billing_cycle: "monthly",
+    price_cents: 6000,
+    currency: "EUR",
+    cancel_policy: "Light + scheda allenamento personalizzata cartacea.",
+  },
+  {
+    name: "Action Top",
+    billing_cycle: "yearly",
+    price_cents: 90000,
+    currency: "EUR",
+    cancel_policy: "Light + scheda + piano alimentare.",
+  },
+  {
+    name: "Fit",
+    billing_cycle: "monthly",
+    price_cents: 5000,
+    currency: "EUR",
+    cancel_policy: "Accesso illimitato Corsi Fitness.",
+  },
+  {
+    name: "Perfect",
+    billing_cycle: "monthly",
+    price_cents: 6500,
+    currency: "EUR",
+    cancel_policy: "Sala Pesi light + Corsi Fitness illimitati.",
+  },
+  {
+    name: "University",
+    billing_cycle: "monthly",
+    price_cents: 4500,
+    currency: "EUR",
+    cancel_policy: "Per studenti universitari (Sala Pesi light o Corsi Fitness).",
+  },
+  {
+    name: "DodiciSedici",
+    billing_cycle: "monthly",
+    price_cents: 3500,
+    currency: "EUR",
+    cancel_policy: "Sala pesi in fascia oraria 12:00 - 16:00.",
+  },
+  {
+    name: "Spartan F.T.",
+    billing_cycle: "monthly",
+    price_cents: 5500,
+    currency: "EUR",
+    cancel_policy: "Accesso illimitato alle lezioni Spartan Functional Training.",
+  },
+  {
+    name: "Free Card 2 Corsi",
+    billing_cycle: "monthly",
+    price_cents: 8500,
+    currency: "EUR",
+    cancel_policy: "Due corsi a scelta.",
+  },
+  {
+    name: "One Drop-in",
+    billing_cycle: "dropin",
+    price_cents: 1200,
+    currency: "EUR",
+    cancel_policy: "Singolo ingresso senza iscrizione.",
+  },
+];
+
+interface ClassTemplate {
+  weekday: number; // 1=Monday through 6=Saturday (matches Date.getDay())
+  start: string; // "HH:mm"
+  end: string;
+  title: string;
+  description: string;
+  capacity: number;
+}
+
+const BZONE_CLASSES: ClassTemplate[] = [
+  // Monday
+  { weekday: 1, start: "09:30", end: "10:30", title: "Pilates Mattina", description: "Pilates matwork, postura e core.", capacity: 12 },
+  { weekday: 1, start: "18:00", end: "19:00", title: "Functional Training", description: "Allenamento funzionale a corpo libero e con piccoli attrezzi.", capacity: 15 },
+  { weekday: 1, start: "19:30", end: "20:30", title: "Tone UP", description: "Lezione di tonificazione full-body.", capacity: 20 },
+  // Tuesday
+  { weekday: 2, start: "10:00", end: "11:00", title: "ABS Stretch", description: "Addominali e stretching.", capacity: 20 },
+  { weekday: 2, start: "18:00", end: "19:00", title: "G.A.G.", description: "Gambe, Addominali, Glutei.", capacity: 20 },
+  { weekday: 2, start: "19:30", end: "20:30", title: "Pilates", description: "Pilates matwork, postura e core.", capacity: 12 },
+  // Wednesday
+  { weekday: 3, start: "12:30", end: "13:30", title: "The Circuit Lunch", description: "Circuit training in pausa pranzo.", capacity: 15 },
+  { weekday: 3, start: "18:00", end: "19:00", title: "Strong Cardio", description: "Cardio intensivo con musica.", capacity: 15 },
+  { weekday: 3, start: "19:30", end: "20:30", title: "The Circuit", description: "Circuit training ad alta intensita.", capacity: 15 },
+  // Thursday
+  { weekday: 4, start: "10:00", end: "11:00", title: "Pilates Mattina", description: "Pilates matwork.", capacity: 12 },
+  { weekday: 4, start: "18:00", end: "19:00", title: "ABS Stretch", description: "Addominali e stretching.", capacity: 20 },
+  { weekday: 4, start: "19:30", end: "20:30", title: "Spartan Functional Training", description: "Functional intenso stile Spartan Race.", capacity: 12 },
+  // Friday
+  { weekday: 5, start: "09:30", end: "10:30", title: "Tone UP Mattina", description: "Tonificazione mattutina.", capacity: 20 },
+  { weekday: 5, start: "18:00", end: "19:00", title: "Functional Training", description: "Allenamento funzionale.", capacity: 15 },
+  { weekday: 5, start: "19:30", end: "20:30", title: "G.A.G.", description: "Gambe, Addominali, Glutei.", capacity: 20 },
+  // Saturday
+  { weekday: 6, start: "10:00", end: "11:00", title: "Tone UP", description: "Tonificazione del sabato mattina.", capacity: 20 },
+  { weekday: 6, start: "11:15", end: "12:15", title: "Functional Training", description: "Functional weekend.", capacity: 15 },
+];
+
+function nextOrSameWeekday(targetWeekday: number, base: Date): Date {
+  const d = new Date(base);
+  const diff = (targetWeekday - d.getDay() + 7) % 7;
+  d.setDate(d.getDate() + diff);
+  return d;
+}
+
+function buildClassTime(weekday: number, hhmm: string, weekOffset: number, base: Date): string {
+  const [h, m] = hhmm.split(":").map(Number);
+  const d = nextOrSameWeekday(weekday, base);
+  d.setDate(d.getDate() + weekOffset * 7);
+  d.setHours(h, m, 0, 0);
+  return d.toISOString();
+}
+
+const NUM_WEEKS = 4;
+
+const BZONE_MANUAL_BILLING = {
+  instructions:
+    "Pay by bank transfer or at reception. Staff will confirm the membership after the payment is recorded.",
+  bankAccountLabel: "BZone demo billing account",
+  accountHolder: "BZone Fitness",
+  iban: "IT00X0000000000000000000000",
+  paymentReferenceFormat: "KRUXT {member name} {invoice id}",
+  cashDeskNote: "Cash and POS payments can be made at reception during staffed hours.",
+  externalPaymentUrl: "https://www.bzonefitness.it/contatti/"
+};
+
+export async function seedBzoneDemoData(
+  supabase: SupabaseClient,
+  gymId: string
+): Promise<SeedResult> {
+  // 1. Membership plans (idempotent; unique on gym_id+name)
+  const planRows = BZONE_PLANS.map((p) => ({
+    gym_id: gymId,
+    name: p.name,
+    billing_cycle: p.billing_cycle,
+    price_cents: p.price_cents,
+    currency: p.currency,
+    cancel_policy: p.cancel_policy,
+    is_active: true,
+  }));
+
+  const { error: planError } = await supabase
+    .from("gym_membership_plans")
+    .upsert(planRows, { onConflict: "gym_id,name" });
+  if (planError) throw new Error(`Plans: ${planError.message}`);
+
+  // 2. Classes: only insert if no classes exist yet (avoids duplicating the
+  // weekly grid every time someone hits the seed button).
+  const { count: existingClassCount, error: countError } = await supabase
+    .from("gym_classes")
+    .select("id", { head: true, count: "exact" })
+    .eq("gym_id", gymId);
+  if (countError) throw new Error(`Class count: ${countError.message}`);
+
+  let classesCreated = 0;
+  let classesSkipped = false;
+
+  if ((existingClassCount ?? 0) > 0) {
+    classesSkipped = true;
+  } else {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const classRows: Record<string, unknown>[] = [];
+    for (let weekOffset = 0; weekOffset < NUM_WEEKS; weekOffset++) {
+      for (const c of BZONE_CLASSES) {
+        classRows.push({
+          gym_id: gymId,
+          title: c.title,
+          description: c.description,
+          capacity: c.capacity,
+          status: "scheduled",
+          starts_at: buildClassTime(c.weekday, c.start, weekOffset, today),
+          ends_at: buildClassTime(c.weekday, c.end, weekOffset, today),
+        });
+      }
+    }
+    const { error: classError } = await supabase.from("gym_classes").insert(classRows);
+    if (classError) throw new Error(`Classes: ${classError.message}`);
+    classesCreated = classRows.length;
+  }
+
+  // 3. Waiver (idempotent; unique on gym_id+title+policy_version)
+  const { error: waiverError } = await supabase.from("waivers").upsert(
+    {
+      gym_id: gymId,
+      title: "Liberatoria salute e responsabilita",
+      policy_version: "v1.0",
+      language_code: "it",
+      document_url: "https://www.bzonefitness.it/bzone_gdpr/",
+      is_active: true,
+    },
+    { onConflict: "gym_id,title,policy_version" }
+  );
+  if (waiverError) throw new Error(`Waiver: ${waiverError.message}`);
+
+  // 4. Manual billing instructions shown beside open member invoices.
+  const { error: billingError } = await supabase.from("gym_feature_settings").upsert(
+    {
+      gym_id: gymId,
+      feature_key: "manual_billing",
+      enabled: true,
+      rollout_percentage: 100,
+      config: BZONE_MANUAL_BILLING,
+      note: "BZone demo manual payment instructions"
+    },
+    { onConflict: "gym_id,feature_key" }
+  );
+  if (billingError) throw new Error(`Billing settings: ${billingError.message}`);
+
+  return {
+    plansUpserted: planRows.length,
+    classesCreated,
+    classesSkipped,
+    waiverUpserted: true,
+    billingSettingsUpserted: true,
+  };
+}

--- a/apps/platform/src/app/(dashboard)/tenants/page.tsx
+++ b/apps/platform/src/app/(dashboard)/tenants/page.tsx
@@ -50,9 +50,13 @@ export default function TenantsPage() {
     return true;
   });
 
-  const counts = {
+  const counts: Record<TenantStatus | "all", number> = {
     all: mockTenants.length,
-    ...Object.fromEntries(statusFilters.map((s) => [s, mockTenants.filter((t) => t.status === s).length])),
+    active: mockTenants.filter((t) => t.status === "active").length,
+    trial: mockTenants.filter((t) => t.status === "trial").length,
+    onboarding: mockTenants.filter((t) => t.status === "onboarding").length,
+    suspended: mockTenants.filter((t) => t.status === "suspended").length,
+    churned: mockTenants.filter((t) => t.status === "churned").length,
   };
 
   return (

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "clean:local": "node scripts/clean-local-caches.mjs",
+    "clean:local:dry": "node scripts/clean-local-caches.mjs --dry-run",
+    "clean:local:deps": "node scripts/clean-local-caches.mjs --include-node-modules",
     "db:test": "bash packages/db/tests/run_smoke.sh"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,12 +72,18 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.49.1
         version: 2.97.0
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       next:
         specifier: ^14.2.0
         version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1321,7 +1327,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
@@ -2025,6 +2031,9 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
@@ -2415,6 +2424,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -2552,6 +2564,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
@@ -2598,6 +2614,9 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -3876,6 +3895,10 @@ packages:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -3969,6 +3992,11 @@ packages:
 
   qrcode-terminal@0.11.0:
     resolution: {integrity: sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==}
+    hasBin: true
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
 
   query-string@7.1.3:
@@ -4143,6 +4171,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
   requireg@0.2.2:
     resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}
     engines: {node: '>= 4.0.0'}
@@ -4249,6 +4280,9 @@ packages:
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -4731,6 +4765,9 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
@@ -4742,6 +4779,10 @@ packages:
 
   wonka@6.3.5:
     resolution: {integrity: sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -4816,6 +4857,9 @@ packages:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -4826,9 +4870,17 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -6962,6 +7014,10 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
@@ -7400,6 +7456,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -7534,6 +7596,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decode-uri-component@0.2.2: {}
 
   deep-extend@0.6.0: {}
@@ -7571,6 +7635,8 @@ snapshots:
   detect-libc@1.0.3: {}
 
   didyoumean@1.2.2: {}
+
+  dijkstrajs@1.0.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -8988,6 +9054,8 @@ snapshots:
 
   pngjs@3.4.0: {}
 
+  pngjs@5.0.0: {}
+
   postcss-import@15.1.0(postcss@8.5.8):
     dependencies:
       postcss: 8.5.8
@@ -9076,6 +9144,12 @@ snapshots:
   punycode@2.3.1: {}
 
   qrcode-terminal@0.11.0: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   query-string@7.1.3:
     dependencies:
@@ -9337,6 +9411,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-main-filename@2.0.0: {}
+
   requireg@0.2.2:
     dependencies:
       nested-error-stacks: 2.0.1
@@ -9473,6 +9549,8 @@ snapshots:
       - supports-color
 
   server-only@0.0.1: {}
+
+  set-blocking@2.0.0: {}
 
   setimmediate@1.0.5: {}
 
@@ -9877,6 +9955,8 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  which-module@2.0.1: {}
+
   which@1.3.1:
     dependencies:
       isexe: 2.0.0
@@ -9886,6 +9966,12 @@ snapshots:
       isexe: 2.0.0
 
   wonka@6.3.5: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -9936,13 +10022,34 @@ snapshots:
 
   xmlbuilder@15.1.1: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:

--- a/scripts/clean-local-caches.mjs
+++ b/scripts/clean-local-caches.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+import { readdir, rm, stat } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import process from "node:process";
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const includeNodeModules = args.has("--include-node-modules");
+
+const cacheNames = new Set([
+  ".expo",
+  ".expo-shared",
+  ".next",
+  ".turbo",
+  ".vite",
+  "build",
+  "coverage",
+  "dist"
+]);
+
+if (includeNodeModules) {
+  cacheNames.add("node_modules");
+}
+
+const exactPaths = ["supabase/.temp"];
+
+function formatBytes(bytes) {
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+async function exists(targetPath) {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function dirSize(targetPath) {
+  let total = 0;
+  const entries = await readdir(targetPath, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(targetPath, entry.name);
+
+    try {
+      if (entry.isDirectory()) {
+        total += await dirSize(entryPath);
+      } else {
+        total += (await stat(entryPath)).size;
+      }
+    } catch {
+      // The cache may change while we inspect it. Skip unstable entries.
+    }
+  }
+
+  return total;
+}
+
+async function workspaceRoots() {
+  const roots = [rootDir];
+
+  for (const folder of ["apps", "packages"]) {
+    const folderPath = path.join(rootDir, folder);
+
+    if (!(await exists(folderPath))) {
+      continue;
+    }
+
+    const entries = await readdir(folderPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        roots.push(path.join(folderPath, entry.name));
+      }
+    }
+  }
+
+  return roots;
+}
+
+async function main() {
+  const candidates = [];
+
+  for (const workspaceRoot of await workspaceRoots()) {
+    for (const cacheName of cacheNames) {
+      const targetPath = path.join(workspaceRoot, cacheName);
+
+      if (await exists(targetPath)) {
+        candidates.push(targetPath);
+      }
+    }
+  }
+
+  for (const relativePath of exactPaths) {
+    const targetPath = path.join(rootDir, relativePath);
+
+    if (await exists(targetPath)) {
+      candidates.push(targetPath);
+    }
+  }
+
+  if (candidates.length === 0) {
+    console.log("No local caches found.");
+    return;
+  }
+
+  let totalBytes = 0;
+  const measured = [];
+
+  for (const targetPath of candidates) {
+    const size = await dirSize(targetPath);
+    totalBytes += size;
+    measured.push({ targetPath, size });
+  }
+
+  const mode = dryRun ? "Would remove" : "Removing";
+  console.log(`${mode} ${measured.length} local cache path(s), about ${formatBytes(totalBytes)}.`);
+
+  for (const item of measured) {
+    console.log(`- ${path.relative(rootDir, item.targetPath)} (${formatBytes(item.size)})`);
+
+    if (!dryRun) {
+      await rm(item.targetPath, { recursive: true, force: true });
+    }
+  }
+
+  if (!includeNodeModules) {
+    console.log("Tip: run with --include-node-modules when you want to reclaim dependency folders too.");
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
Salvages Codex's massive admin rewrite + my onboarding form + BZone seed.

**Members**: profile search-by-name (no more UUIDs), shareable `/join?code=` invite codes with QR, coach assignment per member.
**Settings**: per-gym brand customization (logo, colors, copy).
**Billing**: manual invoice payment recording (cash/bank transfer).
**Staff**: new shifts page.
**New**: in-app gym onboarding form + BZone Pavia demo seed.
**Services**: +900 LOC across gym-admin-service & b2b-ops-service.

Depends on #63 (foundation: types/db).

🤖 Codex's work salvaged & shipped by Claude