### PR TITLE
fix(infra): devcontainer pnpm install failed with EACCES

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "onCreateCommand": "corepack enable && corepack prepare pnpm@10.6.5 --activate",
+  "onCreateCommand": "npm install -g pnpm@10.6.5",
   "postCreateCommand": "pnpm install --frozen-lockfile",
   "forwardPorts": [3000, 3100, 3200, 8081, 19000, 19006],
   "portsAttributes": {


### PR DESCRIPTION
First codespace boot (issue #77) failed container creation: `corepack enable` in onCreateCommand needs root to symlink into /usr/local/bin, so Codespaces fell back to a recovery container. Replace with `npm install -g pnpm@10.6.5` (user-writable global dir in the typescript-node image). Verified root cause from /workspaces/.codespaces/.persistedshare/creation.log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)