### PR TITLE
fix(infra): devcontainer needs sshd for gh codespace ssh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
   "name": "KRUXT Beta (pnpm + turbo monorepo)",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/sshd:1": {}
   },
   "onCreateCommand": "npm install -g pnpm@10.6.5",
   "postCreateCommand": "pnpm install --frozen-lockfile",


### PR DESCRIPTION
Follow-up to #81: the rebuilt codespace container has no SSH server, so `gh codespace ssh` cannot connect (the recovery container had one, masking this). Adds ghcr.io/devcontainers/features/sshd:1. Part of issue #77 verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)