### PR TITLE
feat(mobile): poster thumbnails for video proofs

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,6 +31,7 @@
     "expo-splash-screen": "~0.29.0",
     "expo-status-bar": "~2.0.0",
     "expo-video": "~2.0.6",
+    "expo-video-thumbnails": "~9.0.3",
     "immer": "^10.1.1",
     "react": "18.3.1",
     "react-native": "0.76.0",

--- a/apps/mobile/src/screens/ProofFeedScreen.tsx
+++ b/apps/mobile/src/screens/ProofFeedScreen.tsx
@@ -238,6 +238,7 @@ export function ProofFeedScreen() {
               {/* Full-bleed video — autoplays only when this card is centered */}
               <ProofVideoCard
                 uri={workout.proofMediaUrl}
+                posterUri={workout.proofMediaThumbnailUrl}
                 isActive={activeKey === item.key}
               />
               <View style={styles.mediaScrim} pointerEvents="none" />

--- a/apps/mobile/src/screens/ProofVideoCard.tsx
+++ b/apps/mobile/src/screens/ProofVideoCard.tsx
@@ -1,23 +1,40 @@
-import React, { useEffect } from "react";
-import { StyleSheet } from "react-native";
+import React, { useEffect, useState } from "react";
+import { Image, StyleSheet } from "react-native";
 import { useVideoPlayer, VideoView } from "expo-video";
 
 /**
  * Full-bleed muted, looping video background for a Proof Feed card.
  * Plays only when the card is the active (centered) page so we never have
  * multiple videos playing at once — TikTok-style.
+ *
+ * `posterUri` (the proof thumbnail) is shown over the player until the video
+ * actually starts rendering frames, so cards never flash black before playback.
  */
 export function ProofVideoCard({
   uri,
+  posterUri,
   isActive,
 }: {
   uri: string;
+  posterUri?: string | null;
   isActive: boolean;
 }) {
+  const [showPoster, setShowPoster] = useState(true);
+
   const player = useVideoPlayer(uri, (p) => {
     p.loop = true;
     p.muted = true;
   });
+
+  // Drop the poster once the first frame is actually playing.
+  useEffect(() => {
+    const sub = player.addListener("playingChange", (payload) => {
+      if (payload.isPlaying) {
+        setShowPoster(false);
+      }
+    });
+    return () => sub.remove();
+  }, [player]);
 
   useEffect(() => {
     if (isActive) {
@@ -28,19 +45,34 @@ export function ProofVideoCard({
   }, [isActive, player]);
 
   return (
-    <VideoView
-      style={styles.video}
-      player={player}
-      contentFit="cover"
-      nativeControls={false}
-      allowsFullscreen={false}
-      allowsPictureInPicture={false}
-    />
+    <>
+      <VideoView
+        style={styles.video}
+        player={player}
+        contentFit="cover"
+        nativeControls={false}
+        allowsFullscreen={false}
+        allowsPictureInPicture={false}
+      />
+      {showPoster && posterUri ? (
+        <Image
+          source={{ uri: posterUri }}
+          style={styles.poster}
+          resizeMode="cover"
+          accessibilityIgnoresInvertColors
+        />
+      ) : null}
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   video: {
+    ...StyleSheet.absoluteFillObject,
+    width: "100%",
+    height: "100%",
+  },
+  poster: {
     ...StyleSheet.absoluteFillObject,
     width: "100%",
     height: "100%",

--- a/apps/mobile/src/services/workout-service.ts
+++ b/apps/mobile/src/services/workout-service.ts
@@ -7,6 +7,7 @@ import type {
   WorkoutVisibility
 } from "@kruxt/types";
 import { translateLegalText } from "@kruxt/types";
+import * as VideoThumbnails from "expo-video-thumbnails";
 
 import { KruxtAppError, throwIfError } from "./errors";
 
@@ -350,15 +351,74 @@ export class WorkoutService {
       );
     }
 
+    // For videos, generate a poster frame so the feed never flashes black
+    // before playback. Best-effort — a thumbnail failure must not fail the
+    // proof upload, so the feed falls back to no poster.
+    const update: {
+      proof_media_url: string;
+      proof_media_type: "image" | "video";
+      proof_media_thumbnail_url?: string | null;
+    } = { proof_media_url: publicUrl, proof_media_type: mediaType };
+
+    if (mediaType === "video") {
+      update.proof_media_thumbnail_url = await this.uploadVideoThumbnail(
+        userId,
+        workoutId,
+        media.uri
+      );
+    }
+
     const { error: updateError } = await this.supabase
       .from("workouts")
-      .update({ proof_media_url: publicUrl, proof_media_type: mediaType })
+      .update(update)
       .eq("id", workoutId)
       .eq("user_id", userId);
 
     throwIfError(updateError, "WORKOUT_PROOF_ATTACH_FAILED", "Unable to attach proof media to the workout.");
 
     return { url: publicUrl, type: mediaType };
+  }
+
+  /**
+   * Generate a poster frame from the local video and upload it alongside the
+   * proof. Returns the public URL, or null if anything fails — callers must
+   * treat a missing thumbnail as non-fatal.
+   */
+  private async uploadVideoThumbnail(
+    userId: string,
+    workoutId: string,
+    videoUri: string
+  ): Promise<string | null> {
+    try {
+      const { uri: thumbUri } = await VideoThumbnails.getThumbnailAsync(videoUri, {
+        time: 0,
+        quality: 0.7
+      });
+
+      const response = await fetch(thumbUri);
+      const buffer = await response.arrayBuffer();
+      const bytes = new Uint8Array(buffer);
+
+      const path = `${userId}/${workoutId}_thumb.jpg`;
+      const storage = this.supabase.storage.from(PROOF_BUCKET);
+      const { error: uploadError } = await storage.upload(path, bytes, {
+        contentType: "image/jpeg",
+        upsert: true,
+        cacheControl: "3600"
+      });
+
+      if (uploadError) {
+        return null;
+      }
+
+      const {
+        data: { publicUrl }
+      } = storage.getPublicUrl(path);
+
+      return publicUrl ?? null;
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       expo-video:
         specifier: ~2.0.6
         version: 2.0.6(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      expo-video-thumbnails:
+        specifier: ~9.0.3
+        version: 9.0.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
       immer:
         specifier: ^10.1.1
         version: 10.2.0
@@ -3319,6 +3322,11 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-video-thumbnails@9.0.3:
+    resolution: {integrity: sha512-WDbYMNlcTN/jBnjXZkHWqbgWloHUpG8ZQfie/Ic+BcJagG00TenHcbdzEYiIjshcF4Hhvl3D8okbPFjDFip9/Q==}
+    peerDependencies:
+      expo: '*'
 
   expo-video@2.0.6:
     resolution: {integrity: sha512-oDorKwjreHT596oY6ZfktbDa3VF+Sq7gVsTbnQ4QVqGYL13mIO0s+h4y9xMyG/cDWyFpiRc4UT8KkPdxL0wViQ==}
@@ -9191,8 +9199,8 @@ snapshots:
       '@typescript-eslint/parser': 8.59.4(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -9211,7 +9219,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9222,22 +9230,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.4(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9248,7 +9256,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9523,6 +9531,10 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-native: 0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
+
+  expo-video-thumbnails@9.0.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)):
+    dependencies:
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
 
   expo-video@2.0.6(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.0(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
Closes #74 — video proof cards no longer flash black before playback.

**Generate** (`WorkoutService.attachProofMedia`): poster frame from the local video via expo-video-thumbnails (t=0), uploaded to `<userId>/<id>_thumb.jpg`, populates the existing `proof_media_thumbnail_url` column. Best-effort — a thumbnail failure never fails the proof upload. No schema change (column already existed; Codex's lane untouched).

**Render** (`ProofVideoCard`): poster overlay shown until the first frame plays (`playingChange`), then dropped. `ProofFeedScreen` passes `proofMediaThumbnailUrl`. Videos without a thumbnail behave exactly as before.

Adds `expo-video-thumbnails ~9.0.3` (bundled in Expo Go SDK 52). Typecheck clean; mobile-only.

— Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)