### PR TITLE
feat(mobile): wire Terms / Privacy / Help & support links

### DIFF
--- a/apps/mobile/src/config/links.ts
+++ b/apps/mobile/src/config/links.ts
@@ -1,0 +1,21 @@
+/**
+ * Centralized external links surfaced in the app (Profile → Support).
+ *
+ * Legal pages live on the brand site (see the policy seed:
+ * kruxt.app/legal/...). Override the brand base with EXPO_PUBLIC_APP_WEB_URL
+ * if the marketing/legal site moves.
+ */
+const BRAND_SITE = process.env.EXPO_PUBLIC_APP_WEB_URL ?? "https://kruxt.app";
+
+export const SUPPORT_EMAIL = "support@kruxt.app";
+
+export const APP_LINKS = {
+  terms: `${BRAND_SITE}/legal/terms`,
+  privacy: `${BRAND_SITE}/legal/privacy`,
+  help: `${BRAND_SITE}/help`,
+} as const;
+
+/** Build a mailto: URL with an optional prefilled subject. */
+export function supportMailto(subject: string): string {
+  return `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(subject)}`;
+}

--- a/apps/mobile/src/screens/ProfileScreen.tsx
+++ b/apps/mobile/src/screens/ProfileScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef, useState } from "react";
 import {
   Alert,
+  Linking,
   Pressable,
   RefreshControl,
   SafeAreaView,
@@ -24,6 +25,7 @@ import {
 import { darkTheme } from "@kruxt/ui/theme";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useAuth } from "../contexts/auth-context";
+import { APP_LINKS, supportMailto } from "../config/links";
 import {
   createMobileSupabaseClient,
   GymService,
@@ -145,6 +147,16 @@ export function ProfileScreen() {
       }
       return units;
     });
+  }, []);
+
+  const openExternal = useCallback(async (url: string) => {
+    try {
+      const ok = await Linking.canOpenURL(url);
+      if (!ok) throw new Error("unsupported");
+      await Linking.openURL(url);
+    } catch {
+      Alert.alert("Couldn't open link", "No app is available to handle this link.");
+    }
   }, []);
 
   const handleSignOut = useCallback(() => {
@@ -445,31 +457,31 @@ export function ProfileScreen() {
             theme={theme}
             label="Help Center"
             chevron
-            onPress={() => {/* TODO */}}
+            onPress={() => openExternal(APP_LINKS.help)}
           />
           <ListRow
             theme={theme}
             label="Report a Bug"
             chevron
-            onPress={() => {/* TODO */}}
+            onPress={() => openExternal(supportMailto("KRUXT Bug Report"))}
           />
           <ListRow
             theme={theme}
             label="Contact Support"
             chevron
-            onPress={() => {/* TODO */}}
+            onPress={() => openExternal(supportMailto("KRUXT Support Request"))}
           />
           <ListRow
             theme={theme}
             label="Terms of Service"
             chevron
-            onPress={() => {/* TODO */}}
+            onPress={() => openExternal(APP_LINKS.terms)}
           />
           <ListRow
             theme={theme}
             label="Privacy Policy"
             chevron
-            onPress={() => {/* TODO */}}
+            onPress={() => openExternal(APP_LINKS.privacy)}
           />
         </SettingsGroup>
 


### PR DESCRIPTION
Closes #90 — Profile → Support rows are no longer stubs.

- New `src/config/links.ts` centralizes external links: legal pages at `kruxt.app/legal/{terms,privacy}` (matches the policy seed), Help Center, and a support `mailto`. Brand base overridable via `EXPO_PUBLIC_APP_WEB_URL`.
- `ProfileScreen` opens them through a safe `openExternal` helper (`canOpenURL` guard + Alert fallback). Terms/Privacy/Help → browser; Report a Bug / Contact Support → prefilled mailto.

Typecheck clean; mobile-only. URLs/email are centralized in one file so you can correct them if the real support address or legal paths differ.

— Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)