### PR TITLE
[codex] Backfill video proof thumbnails

### DIFF
--- a/.github/workflows/backfill-video-proof-thumbnails.yml
+++ b/.github/workflows/backfill-video-proof-thumbnails.yml
@@ -41,6 +41,7 @@ jobs:
       cancel-in-progress: false
     env:
       STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+      STAGING_SUPABASE_SECRET_KEY: ${{ secrets.STAGING_SUPABASE_SECRET_KEY }}
       STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
       STAGING_SUPABASE_PROJECT_REF: upwcpcjjfggdcmizgbka
       REPORT_FILE: video-proof-thumbnail-backfill-report.json
@@ -59,8 +60,13 @@ jobs:
           MODE: ${{ inputs.mode }}
           CONFIRM: ${{ inputs.confirm }}
         run: |
-          if [ -z "${STAGING_SUPABASE_URL:-}" ] || [ -z "${STAGING_SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
-            echo "Missing STAGING_SUPABASE_URL or STAGING_SUPABASE_SERVICE_ROLE_KEY." >&2
+          if [ -z "${STAGING_SUPABASE_URL:-}" ]; then
+            echo "Missing STAGING_SUPABASE_URL." >&2
+            exit 1
+          fi
+
+          if [ -z "${STAGING_SUPABASE_SECRET_KEY:-}" ] && [ -z "${STAGING_SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+            echo "Missing STAGING_SUPABASE_SECRET_KEY (preferred) or legacy STAGING_SUPABASE_SERVICE_ROLE_KEY." >&2
             exit 1
           fi
 

--- a/.github/workflows/backfill-video-proof-thumbnails.yml
+++ b/.github/workflows/backfill-video-proof-thumbnails.yml
@@ -1,0 +1,112 @@
+name: backfill-video-proof-thumbnails
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Dry-run scans only; apply uploads thumbnails and updates workout rows"
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - apply
+      limit:
+        description: "Maximum workouts to process (1-1000)"
+        required: true
+        default: "100"
+        type: number
+      frame_seconds:
+        description: "Preferred poster timestamp in seconds (0-60)"
+        required: true
+        default: "0"
+        type: string
+      workout_ids:
+        description: "Optional comma-separated workout UUIDs (maximum 100)"
+        required: false
+        type: string
+      confirm:
+        description: "Type BACKFILL to allow apply mode"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: staging-video-proof-thumbnail-backfill
+      cancel-in-progress: false
+    env:
+      STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+      STAGING_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+      STAGING_SUPABASE_PROJECT_REF: upwcpcjjfggdcmizgbka
+      REPORT_FILE: video-proof-thumbnail-backfill-report.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Validate staging guardrails
+        shell: bash
+        env:
+          MODE: ${{ inputs.mode }}
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          if [ -z "${STAGING_SUPABASE_URL:-}" ] || [ -z "${STAGING_SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+            echo "Missing STAGING_SUPABASE_URL or STAGING_SUPABASE_SERVICE_ROLE_KEY." >&2
+            exit 1
+          fi
+
+          if [ "$MODE" = "apply" ] && [ "$CONFIRM" != "BACKFILL" ]; then
+            echo "Apply mode requires confirm=BACKFILL." >&2
+            exit 1
+          fi
+
+      - name: Ensure ffmpeg is available
+        shell: bash
+        run: |
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
+          fi
+          ffmpeg -version
+
+      - name: Run focused tests
+        run: node --test packages/db/tests/backfill-video-proof-thumbnails.test.mjs
+
+      - name: Run backfill
+        shell: bash
+        env:
+          MODE: ${{ inputs.mode }}
+          LIMIT: ${{ inputs.limit }}
+          FRAME_SECONDS: ${{ inputs.frame_seconds }}
+          WORKOUT_IDS: ${{ inputs.workout_ids }}
+        run: |
+          args=(
+            --mode "$MODE"
+            --limit "$LIMIT"
+            --frame-seconds "$FRAME_SECONDS"
+            --output-file "$REPORT_FILE"
+          )
+
+          if [ -n "${WORKOUT_IDS:-}" ]; then
+            args+=(--workout-ids "$WORKOUT_IDS")
+          fi
+
+          node packages/db/scripts/backfill-video-proof-thumbnails.mjs "${args[@]}"
+
+      - name: Upload backfill report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: video-proof-thumbnail-backfill-${{ github.run_id }}
+          path: ${{ env.REPORT_FILE }}
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/video-proof-thumbnail-backfill.md
+++ b/docs/video-proof-thumbnail-backfill.md
@@ -5,7 +5,8 @@ create poster images for video proofs that predate thumbnail generation.
 
 ## Safety Model
 
-- The job only accepts staging credentials: `STAGING_SUPABASE_URL` and
+- The job only accepts staging credentials: `STAGING_SUPABASE_URL` plus
+  `STAGING_SUPABASE_SECRET_KEY` (preferred) or the legacy
   `STAGING_SUPABASE_SERVICE_ROLE_KEY`.
 - The script also verifies the URL resolves to the known staging project
   `upwcpcjjfggdcmizgbka`, preventing a production credential mix-up.
@@ -21,7 +22,8 @@ Do not configure these staging-prefixed secrets with production credentials.
 
 ## First Run
 
-1. Add the two staging secrets in GitHub repository settings.
+1. Add `STAGING_SUPABASE_URL` and `STAGING_SUPABASE_SECRET_KEY` in GitHub
+   repository settings. The legacy service-role key name remains supported.
 2. Open **Actions > backfill-video-proof-thumbnails > Run workflow**.
 3. Keep `mode` set to `dry-run` and use a small limit such as `10`.
 4. Review the job summary and downloaded JSON report.
@@ -44,7 +46,7 @@ The backfill itself requires staging credentials:
 
 ```sh
 STAGING_SUPABASE_URL="https://..." \
-STAGING_SUPABASE_SERVICE_ROLE_KEY="..." \
+STAGING_SUPABASE_SECRET_KEY="sb_secret_..." \
 node packages/db/scripts/backfill-video-proof-thumbnails.mjs \
   --mode dry-run \
   --limit 10

--- a/docs/video-proof-thumbnail-backfill.md
+++ b/docs/video-proof-thumbnail-backfill.md
@@ -1,0 +1,54 @@
+# Video Proof Thumbnail Backfill
+
+Use the manual `backfill-video-proof-thumbnails` GitHub Actions workflow to
+create poster images for video proofs that predate thumbnail generation.
+
+## Safety Model
+
+- The job only accepts staging credentials: `STAGING_SUPABASE_URL` and
+  `STAGING_SUPABASE_SERVICE_ROLE_KEY`.
+- The script also verifies the URL resolves to the known staging project
+  `upwcpcjjfggdcmizgbka`, preventing a production credential mix-up.
+- `dry-run` is the default and does not upload or update anything.
+- `apply` requires the exact confirmation value `BACKFILL`.
+- The scan is bounded by `limit`, can target explicit workout UUIDs, and is
+  idempotent. Existing thumbnail objects are reused.
+- Workout rows are updated only while `proof_media_thumbnail_url` is still
+  null, so a newer client or concurrent job wins.
+- Each run uploads a JSON report artifact and writes a GitHub job summary.
+
+Do not configure these staging-prefixed secrets with production credentials.
+
+## First Run
+
+1. Add the two staging secrets in GitHub repository settings.
+2. Open **Actions > backfill-video-proof-thumbnails > Run workflow**.
+3. Keep `mode` set to `dry-run` and use a small limit such as `10`.
+4. Review the job summary and downloaded JSON report.
+5. Run again with `mode=apply` and `confirm=BACKFILL`.
+6. Re-run in `dry-run`; a completed batch should scan zero matching workouts.
+
+For a single known record, pass its UUID in `workout_ids`. Multiple IDs are
+comma-separated, with a maximum of 100.
+
+## Local Verification
+
+The focused tests need only Node.js. The frame extraction test runs when
+`ffmpeg` is installed and otherwise reports as skipped.
+
+```sh
+node --test packages/db/tests/backfill-video-proof-thumbnails.test.mjs
+```
+
+The backfill itself requires staging credentials:
+
+```sh
+STAGING_SUPABASE_URL="https://..." \
+STAGING_SUPABASE_SERVICE_ROLE_KEY="..." \
+node packages/db/scripts/backfill-video-proof-thumbnails.mjs \
+  --mode dry-run \
+  --limit 10
+```
+
+The generated poster path matches the mobile app convention:
+`<user_id>/<workout_id>_thumb.jpg` in the public `workout-proof` bucket.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clean:local": "node scripts/clean-local-caches.mjs",
     "clean:local:dry": "node scripts/clean-local-caches.mjs --dry-run",
     "clean:local:deps": "node scripts/clean-local-caches.mjs --include-node-modules",
-    "db:test": "bash packages/db/tests/run_smoke.sh"
+    "db:test": "bash packages/db/tests/run_smoke.sh && node --test packages/db/tests/backfill-video-proof-thumbnails.test.mjs"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -7,6 +7,9 @@ Contains Supabase/Postgres SQL migrations and smoke tests.
 - `supabase/migrations/`: ordered migration set for full KRUXT foundation schema
 - `supabase/seeds/001_feature_flags.sql`: feature-flag defaults
 - `tests/rls_smoke.sql`: checks expected policy coverage by naming convention
+- `scripts/backfill-video-proof-thumbnails.mjs`: bounded staging backfill for
+  poster images on legacy video proofs; see
+  `../../docs/video-proof-thumbnail-backfill.md`
 
 ## Apply
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,6 +6,6 @@
     "build": "echo 'Database package contains SQL migrations only'",
     "lint": "echo 'Add sqlfluff or pg formatter in CI'",
     "typecheck": "echo 'No TypeScript in db package'",
-    "test": "bash tests/run_smoke.sh"
+    "test": "bash tests/run_smoke.sh && node --test tests/backfill-video-proof-thumbnails.test.mjs"
   }
 }

--- a/packages/db/scripts/backfill-video-proof-thumbnails.mjs
+++ b/packages/db/scripts/backfill-video-proof-thumbnails.mjs
@@ -1,0 +1,560 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { extname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const PROOF_BUCKET = "workout-proof";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const DEFAULTS = {
+  mode: "dry-run",
+  limit: 100,
+  pageSize: 50,
+  frameSeconds: 0,
+  outputFile: "video-proof-thumbnail-backfill-report.json",
+  workoutIds: []
+};
+
+export function parseArgs(argv) {
+  const config = { ...DEFAULTS, workoutIds: [] };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+
+    if (argument === "--mode") {
+      config.mode = requireValue(argument, value);
+      index += 1;
+    } else if (argument === "--limit") {
+      config.limit = parseInteger(argument, requireValue(argument, value), 1, 1000);
+      index += 1;
+    } else if (argument === "--page-size") {
+      config.pageSize = parseInteger(argument, requireValue(argument, value), 1, 250);
+      index += 1;
+    } else if (argument === "--frame-seconds") {
+      config.frameSeconds = parseNumber(argument, requireValue(argument, value), 0, 60);
+      index += 1;
+    } else if (argument === "--output-file") {
+      config.outputFile = requireValue(argument, value);
+      index += 1;
+    } else if (argument === "--workout-ids") {
+      config.workoutIds = parseWorkoutIds(requireValue(argument, value));
+      index += 1;
+    } else if (argument === "--help" || argument === "-h") {
+      config.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!["dry-run", "apply"].includes(config.mode)) {
+    throw new Error("--mode must be dry-run or apply");
+  }
+
+  return config;
+}
+
+function requireValue(argument, value) {
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${argument} requires a value`);
+  }
+  return value;
+}
+
+function parseInteger(argument, value, minimum, maximum) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${argument} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+function parseNumber(argument, value, minimum, maximum) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${argument} must be between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+export function parseWorkoutIds(value) {
+  if (!value.trim()) {
+    return [];
+  }
+
+  const ids = [...new Set(value.split(",").map((item) => item.trim()).filter(Boolean))];
+  const invalid = ids.find((id) => !UUID_PATTERN.test(id));
+  if (invalid) {
+    throw new Error(`Invalid workout UUID: ${invalid}`);
+  }
+  if (ids.length > 100) {
+    throw new Error("--workout-ids accepts at most 100 IDs");
+  }
+  return ids;
+}
+
+export function publicObjectUrl(supabaseUrl, objectPath) {
+  return `${supabaseUrl}/storage/v1/object/public/${PROOF_BUCKET}/${encodeObjectPath(objectPath)}`;
+}
+
+export function parseProofObjectPath(proofMediaUrl, supabaseUrl) {
+  if (!proofMediaUrl) {
+    return null;
+  }
+
+  let url;
+  try {
+    url = new URL(proofMediaUrl);
+  } catch {
+    return null;
+  }
+
+  const expectedOrigin = new URL(supabaseUrl).origin;
+  const prefix = `/storage/v1/object/public/${PROOF_BUCKET}/`;
+  if (url.origin !== expectedOrigin || !url.pathname.startsWith(prefix)) {
+    return null;
+  }
+
+  const encodedPath = url.pathname.slice(prefix.length);
+  let objectPath;
+  try {
+    objectPath = encodedPath
+      .split("/")
+      .map((segment) => decodeURIComponent(segment))
+      .join("/");
+  } catch {
+    return null;
+  }
+
+  return isSafeObjectPath(objectPath) ? objectPath : null;
+}
+
+export function chooseSourceObject(objects, workoutId) {
+  const prefix = `${workoutId}.`;
+  const candidates = objects
+    .map((object) => object.name)
+    .filter((name) => name.startsWith(prefix))
+    .filter((name) => !name.endsWith("_thumb.jpg"))
+    .filter((name) => /\.(mp4|mov|m4v|webm)$/i.test(name))
+    .sort();
+
+  return candidates[0] ?? null;
+}
+
+export function sourceBelongsToWorkout(objectPath, userId, workoutId) {
+  const escapedUserId = escapeRegExp(userId);
+  const escapedWorkoutId = escapeRegExp(workoutId);
+  return new RegExp(
+    `^${escapedUserId}/${escapedWorkoutId}\\.(mp4|mov|m4v|webm)$`,
+    "i"
+  ).test(objectPath);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isSafeObjectPath(objectPath) {
+  if (!objectPath || objectPath.startsWith("/") || objectPath.includes("\0")) {
+    return false;
+  }
+
+  const segments = objectPath.split("/");
+  return segments.every((segment) => segment && segment !== "." && segment !== "..");
+}
+
+function encodeObjectPath(objectPath) {
+  if (!isSafeObjectPath(objectPath)) {
+    throw new Error(`Unsafe storage object path: ${objectPath}`);
+  }
+  return objectPath.split("/").map(encodeURIComponent).join("/");
+}
+
+function printHelp() {
+  console.log(`Backfill poster thumbnails for existing KRUXT video proofs.
+
+Usage:
+  node packages/db/scripts/backfill-video-proof-thumbnails.mjs [options]
+
+Options:
+  --mode dry-run|apply       Default: dry-run
+  --limit 1..1000            Maximum workouts to scan. Default: 100
+  --page-size 1..250         PostgREST page size. Default: 50
+  --frame-seconds 0..60      Preferred poster timestamp. Default: 0
+  --workout-ids id,id        Optional targeted UUID list, maximum 100
+  --output-file path         JSON report path
+
+Required environment:
+  STAGING_SUPABASE_URL
+  STAGING_SUPABASE_SERVICE_ROLE_KEY`);
+}
+
+export function validateStagingUrl(supabaseUrl, expectedProjectRef) {
+  let url;
+  try {
+    url = new URL(supabaseUrl);
+  } catch {
+    throw new Error("STAGING_SUPABASE_URL must be a valid URL");
+  }
+
+  const expectedHostname = `${expectedProjectRef}.supabase.co`;
+  if (url.protocol !== "https:" || url.hostname !== expectedHostname) {
+    throw new Error(
+      `Refusing to run against unexpected Supabase host; expected ${expectedHostname}`
+    );
+  }
+
+  return url.origin;
+}
+
+class SupabaseRestClient {
+  constructor(supabaseUrl, serviceRoleKey) {
+    this.supabaseUrl = supabaseUrl.replace(/\/+$/, "");
+    this.serviceRoleKey = serviceRoleKey;
+  }
+
+  headers(extra = {}) {
+    return {
+      apikey: this.serviceRoleKey,
+      Authorization: `Bearer ${this.serviceRoleKey}`,
+      ...extra
+    };
+  }
+
+  async fetchMissingWorkouts({ afterId, limit, workoutIds }) {
+    const url = new URL(`${this.supabaseUrl}/rest/v1/workouts`);
+    url.searchParams.set(
+      "select",
+      "id,user_id,proof_media_url,proof_media_thumbnail_url,created_at"
+    );
+    url.searchParams.set("proof_media_type", "eq.video");
+    url.searchParams.set("proof_media_thumbnail_url", "is.null");
+    url.searchParams.set("order", "id.asc");
+    url.searchParams.set("limit", String(limit));
+
+    if (workoutIds.length > 0) {
+      url.searchParams.set("id", `in.(${workoutIds.join(",")})`);
+    } else if (afterId) {
+      url.searchParams.set("id", `gt.${afterId}`);
+    }
+
+    return this.fetchJson(url, { headers: this.headers() });
+  }
+
+  async listUserObjects(userId, workoutId) {
+    const url = `${this.supabaseUrl}/storage/v1/object/list/${PROOF_BUCKET}`;
+    return this.fetchJson(url, {
+      method: "POST",
+      headers: this.headers({ "Content-Type": "application/json" }),
+      body: JSON.stringify({
+        prefix: `${userId}/`,
+        search: workoutId,
+        limit: 100,
+        offset: 0,
+        sortBy: { column: "name", order: "asc" }
+      })
+    });
+  }
+
+  async downloadObject(objectPath) {
+    const url = `${this.supabaseUrl}/storage/v1/object/${PROOF_BUCKET}/${encodeObjectPath(objectPath)}`;
+    const response = await fetch(url, { headers: this.headers() });
+    if (!response.ok) {
+      throw new Error(`Storage download failed (${response.status}): ${await response.text()}`);
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  async uploadThumbnail(objectPath, bytes) {
+    const url = `${this.supabaseUrl}/storage/v1/object/${PROOF_BUCKET}/${encodeObjectPath(objectPath)}`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: this.headers({
+        "Content-Type": "image/jpeg",
+        "Cache-Control": "3600",
+        "x-upsert": "true"
+      }),
+      body: bytes
+    });
+    if (!response.ok) {
+      throw new Error(`Thumbnail upload failed (${response.status}): ${await response.text()}`);
+    }
+  }
+
+  async setThumbnailIfMissing(workoutId, thumbnailUrl) {
+    const url = new URL(`${this.supabaseUrl}/rest/v1/workouts`);
+    url.searchParams.set("id", `eq.${workoutId}`);
+    url.searchParams.set("proof_media_thumbnail_url", "is.null");
+    const response = await fetch(url, {
+      method: "PATCH",
+      headers: this.headers({
+        "Content-Type": "application/json",
+        Prefer: "return=representation"
+      }),
+      body: JSON.stringify({ proof_media_thumbnail_url: thumbnailUrl })
+    });
+    if (!response.ok) {
+      throw new Error(`Workout update failed (${response.status}): ${await response.text()}`);
+    }
+    const rows = await response.json();
+    return rows.length === 1;
+  }
+
+  async fetchJson(url, init) {
+    const response = await fetch(url, init);
+    if (!response.ok) {
+      throw new Error(`Supabase request failed (${response.status}): ${await response.text()}`);
+    }
+    return response.json();
+  }
+}
+
+export async function extractVideoFrame({
+  sourceFile,
+  outputFile,
+  frameSeconds,
+  spawnProcess = spawn
+}) {
+  const attempts = frameSeconds > 0 ? [frameSeconds, 0] : [0];
+  let lastError;
+
+  for (const timestamp of attempts) {
+    try {
+      await runProcess(
+        spawnProcess,
+        "ffmpeg",
+        [
+          "-hide_banner",
+          "-loglevel",
+          "error",
+          "-y",
+          "-ss",
+          String(timestamp),
+          "-i",
+          sourceFile,
+          "-frames:v",
+          "1",
+          "-vf",
+          "scale=min(1280\\,iw):-2",
+          "-q:v",
+          "3",
+          outputFile
+        ]
+      );
+      return timestamp;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
+function runProcess(spawnProcess, command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawnProcess(command, args, { stdio: ["ignore", "ignore", "pipe"] });
+    let stderr = "";
+
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}: ${stderr.trim()}`));
+      }
+    });
+  });
+}
+
+async function processWorkout(client, workout, config) {
+  const thumbnailPath = `${workout.user_id}/${workout.id}_thumb.jpg`;
+  const objects = await client.listUserObjects(workout.user_id, workout.id);
+  const thumbnailExists = objects.some((object) => object.name === `${workout.id}_thumb.jpg`);
+  const parsedSourcePath = parseProofObjectPath(workout.proof_media_url, client.supabaseUrl);
+  const trustedParsedSourcePath =
+    parsedSourcePath &&
+    sourceBelongsToWorkout(parsedSourcePath, workout.user_id, workout.id)
+      ? parsedSourcePath
+      : null;
+  const listedSourceName = chooseSourceObject(objects, workout.id);
+  const listedSourcePath = listedSourceName ? `${workout.user_id}/${listedSourceName}` : null;
+  const sourcePath = trustedParsedSourcePath ?? listedSourcePath;
+  const thumbnailUrl = publicObjectUrl(client.supabaseUrl, thumbnailPath);
+
+  if (!thumbnailExists && !sourcePath) {
+    return resultFor(workout, "missing_source", { thumbnailPath });
+  }
+
+  if (config.mode === "dry-run") {
+    return resultFor(workout, "would_backfill", {
+      sourcePath,
+      thumbnailPath,
+      reusedExistingThumbnail: thumbnailExists
+    });
+  }
+
+  if (!thumbnailExists) {
+    const directory = await mkdtemp(join(tmpdir(), "kruxt-proof-thumb-"));
+    const sourceExtension = extname(sourcePath) || ".video";
+    const sourceFile = join(directory, `source${sourceExtension}`);
+    const outputFile = join(directory, "thumbnail.jpg");
+
+    try {
+      await writeFile(sourceFile, await client.downloadObject(sourcePath));
+      const extractedAtSeconds = await extractVideoFrame({
+        sourceFile,
+        outputFile,
+        frameSeconds: config.frameSeconds
+      });
+      await client.uploadThumbnail(thumbnailPath, await readFile(outputFile));
+      const updated = await client.setThumbnailIfMissing(workout.id, thumbnailUrl);
+      return resultFor(workout, updated ? "backfilled" : "already_updated", {
+        sourcePath,
+        thumbnailPath,
+        extractedAtSeconds
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+
+  const updated = await client.setThumbnailIfMissing(workout.id, thumbnailUrl);
+  return resultFor(workout, updated ? "linked_existing_thumbnail" : "already_updated", {
+    sourcePath,
+    thumbnailPath
+  });
+}
+
+function resultFor(workout, status, detail = {}) {
+  return {
+    workoutId: workout.id,
+    userId: workout.user_id,
+    status,
+    ...detail
+  };
+}
+
+async function collectWorkouts(client, config) {
+  if (config.workoutIds.length > 0) {
+    return client.fetchMissingWorkouts({
+      afterId: null,
+      limit: Math.min(config.limit, config.workoutIds.length),
+      workoutIds: config.workoutIds
+    });
+  }
+
+  const workouts = [];
+  let cursor = null;
+
+  while (workouts.length < config.limit) {
+    const requestedPageSize = Math.min(config.pageSize, config.limit - workouts.length);
+    const page = await client.fetchMissingWorkouts({
+      afterId: cursor,
+      limit: requestedPageSize,
+      workoutIds: []
+    });
+    workouts.push(...page);
+
+    if (page.length < requestedPageSize) {
+      break;
+    }
+    cursor = page.at(-1)?.id ?? null;
+    if (!cursor) {
+      break;
+    }
+  }
+
+  return workouts;
+}
+
+function summarize(results) {
+  return results.reduce((counts, result) => {
+    counts[result.status] = (counts[result.status] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+async function appendGitHubSummary(report) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) {
+    return;
+  }
+
+  const lines = [
+    "## Video proof thumbnail backfill",
+    "",
+    `- Mode: \`${report.mode}\``,
+    `- Scanned: **${report.scanned}**`,
+    ...Object.entries(report.summary).map(([status, count]) => `- ${status}: **${count}**`),
+    ""
+  ];
+  await writeFile(summaryPath, `${lines.join("\n")}\n`, { flag: "a" });
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const config = parseArgs(argv);
+  if (config.help) {
+    printHelp();
+    return;
+  }
+
+  const supabaseUrl = process.env.STAGING_SUPABASE_URL?.replace(/\/+$/, "");
+  const serviceRoleKey = process.env.STAGING_SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      "STAGING_SUPABASE_URL and STAGING_SUPABASE_SERVICE_ROLE_KEY are required"
+    );
+  }
+  const expectedProjectRef =
+    process.env.STAGING_SUPABASE_PROJECT_REF ?? "upwcpcjjfggdcmizgbka";
+  validateStagingUrl(supabaseUrl, expectedProjectRef);
+
+  const client = new SupabaseRestClient(supabaseUrl, serviceRoleKey);
+  const workouts = await collectWorkouts(client, config);
+  const results = [];
+
+  for (const workout of workouts) {
+    try {
+      const result = await processWorkout(client, workout, config);
+      results.push(result);
+      console.log(`${result.status}: ${workout.id}`);
+    } catch (error) {
+      results.push(resultFor(workout, "failed", { error: error.message }));
+      console.error(`failed: ${workout.id}: ${error.message}`);
+    }
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    supabaseOrigin: new URL(supabaseUrl).origin,
+    mode: config.mode,
+    limit: config.limit,
+    frameSeconds: config.frameSeconds,
+    targetedWorkoutIds: config.workoutIds,
+    scanned: results.length,
+    summary: summarize(results),
+    results
+  };
+  await writeFile(config.outputFile, `${JSON.stringify(report, null, 2)}\n`);
+  await appendGitHubSummary(report);
+  console.log(`Report written to ${config.outputFile}`);
+
+  if (results.some((result) => ["failed", "missing_source"].includes(result.status))) {
+    process.exitCode = 1;
+  }
+}
+
+const isEntryPoint =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isEntryPoint) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/packages/db/scripts/backfill-video-proof-thumbnails.mjs
+++ b/packages/db/scripts/backfill-video-proof-thumbnails.mjs
@@ -189,7 +189,8 @@ Options:
 
 Required environment:
   STAGING_SUPABASE_URL
-  STAGING_SUPABASE_SERVICE_ROLE_KEY`);
+  STAGING_SUPABASE_SECRET_KEY (preferred) or
+  STAGING_SUPABASE_SERVICE_ROLE_KEY (legacy JWT)`);
 }
 
 export function validateStagingUrl(supabaseUrl, expectedProjectRef) {
@@ -210,18 +211,32 @@ export function validateStagingUrl(supabaseUrl, expectedProjectRef) {
   return url.origin;
 }
 
+export function buildPrivilegedHeaders(apiKey, extra = {}) {
+  const isSecretKey = apiKey.startsWith("sb_secret_");
+  const isLegacyServiceRoleJwt = apiKey.split(".").length === 3;
+  if (!isSecretKey && !isLegacyServiceRoleJwt) {
+    throw new Error(
+      "Staging key must be an sb_secret key or legacy service_role JWT"
+    );
+  }
+
+  return {
+    apikey: apiKey,
+    ...(isLegacyServiceRoleJwt
+      ? { Authorization: `Bearer ${apiKey}` }
+      : {}),
+    ...extra
+  };
+}
+
 class SupabaseRestClient {
-  constructor(supabaseUrl, serviceRoleKey) {
+  constructor(supabaseUrl, privilegedKey) {
     this.supabaseUrl = supabaseUrl.replace(/\/+$/, "");
-    this.serviceRoleKey = serviceRoleKey;
+    this.privilegedKey = privilegedKey;
   }
 
   headers(extra = {}) {
-    return {
-      apikey: this.serviceRoleKey,
-      Authorization: `Bearer ${this.serviceRoleKey}`,
-      ...extra
-    };
+    return buildPrivilegedHeaders(this.privilegedKey, extra);
   }
 
   async fetchMissingWorkouts({ afterId, limit, workoutIds }) {
@@ -505,17 +520,19 @@ export async function main(argv = process.argv.slice(2)) {
   }
 
   const supabaseUrl = process.env.STAGING_SUPABASE_URL?.replace(/\/+$/, "");
-  const serviceRoleKey = process.env.STAGING_SUPABASE_SERVICE_ROLE_KEY;
-  if (!supabaseUrl || !serviceRoleKey) {
+  const privilegedKey =
+    process.env.STAGING_SUPABASE_SECRET_KEY ??
+    process.env.STAGING_SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !privilegedKey) {
     throw new Error(
-      "STAGING_SUPABASE_URL and STAGING_SUPABASE_SERVICE_ROLE_KEY are required"
+      "STAGING_SUPABASE_URL and a staging secret/service-role key are required"
     );
   }
   const expectedProjectRef =
     process.env.STAGING_SUPABASE_PROJECT_REF ?? "upwcpcjjfggdcmizgbka";
   validateStagingUrl(supabaseUrl, expectedProjectRef);
 
-  const client = new SupabaseRestClient(supabaseUrl, serviceRoleKey);
+  const client = new SupabaseRestClient(supabaseUrl, privilegedKey);
   const workouts = await collectWorkouts(client, config);
   const results = [];
 

--- a/packages/db/tests/backfill-video-proof-thumbnails.test.mjs
+++ b/packages/db/tests/backfill-video-proof-thumbnails.test.mjs
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 
 import {
+  buildPrivilegedHeaders,
   chooseSourceObject,
   extractVideoFrame,
   parseArgs,
@@ -170,6 +171,25 @@ test("validateStagingUrl only accepts the configured HTTPS project", () => {
       ),
     /Refusing to run/
   );
+});
+
+test("buildPrivilegedHeaders supports modern secret and legacy service-role keys", () => {
+  assert.deepEqual(
+    buildPrivilegedHeaders("sb_secret_example_checksum", {
+      "Content-Type": "application/json"
+    }),
+    {
+      apikey: "sb_secret_example_checksum",
+      "Content-Type": "application/json"
+    }
+  );
+
+  const jwt = "header.payload.signature";
+  assert.deepEqual(buildPrivilegedHeaders(jwt), {
+    apikey: jwt,
+    Authorization: `Bearer ${jwt}`
+  });
+  assert.throws(() => buildPrivilegedHeaders("sb_publishable_public"), /must be/);
 });
 
 test(

--- a/packages/db/tests/backfill-video-proof-thumbnails.test.mjs
+++ b/packages/db/tests/backfill-video-proof-thumbnails.test.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  chooseSourceObject,
+  extractVideoFrame,
+  parseArgs,
+  parseProofObjectPath,
+  parseWorkoutIds,
+  publicObjectUrl,
+  sourceBelongsToWorkout,
+  validateStagingUrl
+} from "../scripts/backfill-video-proof-thumbnails.mjs";
+
+const USER_ID = "082804b4-6f4d-45f6-a05d-a9c28a8a77de";
+const WORKOUT_ID = "0f349f70-d50c-48ba-8b24-dd5db475b903";
+const OTHER_WORKOUT_ID = "ed38cfeb-40fa-43bb-9dbc-82f68ef70f77";
+const SUPABASE_URL = "https://example.supabase.co";
+
+test("parseArgs defaults to a bounded dry run", () => {
+  assert.deepEqual(parseArgs([]), {
+    mode: "dry-run",
+    limit: 100,
+    pageSize: 50,
+    frameSeconds: 0,
+    outputFile: "video-proof-thumbnail-backfill-report.json",
+    workoutIds: []
+  });
+});
+
+test("parseArgs accepts explicit apply options", () => {
+  assert.deepEqual(
+    parseArgs([
+      "--mode",
+      "apply",
+      "--limit",
+      "12",
+      "--page-size",
+      "4",
+      "--frame-seconds",
+      "1.5",
+      "--workout-ids",
+      `${WORKOUT_ID},${OTHER_WORKOUT_ID}`,
+      "--output-file",
+      "report.json"
+    ]),
+    {
+      mode: "apply",
+      limit: 12,
+      pageSize: 4,
+      frameSeconds: 1.5,
+      outputFile: "report.json",
+      workoutIds: [WORKOUT_ID, OTHER_WORKOUT_ID]
+    }
+  );
+});
+
+test("parseArgs rejects unsafe ranges and unknown arguments", () => {
+  assert.throws(() => parseArgs(["--limit", "0"]), /between 1 and 1000/);
+  assert.throws(() => parseArgs(["--frame-seconds", "61"]), /between 0 and 60/);
+  assert.throws(() => parseArgs(["--surprise", "yes"]), /Unknown argument/);
+});
+
+test("parseWorkoutIds validates, trims, and deduplicates UUIDs", () => {
+  assert.deepEqual(
+    parseWorkoutIds(` ${WORKOUT_ID},${WORKOUT_ID}, ${OTHER_WORKOUT_ID} `),
+    [WORKOUT_ID, OTHER_WORKOUT_ID]
+  );
+  assert.throws(() => parseWorkoutIds("not-a-uuid"), /Invalid workout UUID/);
+});
+
+test("publicObjectUrl safely encodes path segments", () => {
+  assert.equal(
+    publicObjectUrl(SUPABASE_URL, `${USER_ID}/proof frame.jpg`),
+    `${SUPABASE_URL}/storage/v1/object/public/workout-proof/${USER_ID}/proof%20frame.jpg`
+  );
+  assert.throws(() => publicObjectUrl(SUPABASE_URL, "../secret"), /Unsafe storage object path/);
+});
+
+test("parseProofObjectPath only accepts the expected origin and bucket", () => {
+  const validUrl = `${SUPABASE_URL}/storage/v1/object/public/workout-proof/${USER_ID}/${WORKOUT_ID}.mp4`;
+  assert.equal(
+    parseProofObjectPath(validUrl, SUPABASE_URL),
+    `${USER_ID}/${WORKOUT_ID}.mp4`
+  );
+  assert.equal(
+    parseProofObjectPath(
+      `https://other.supabase.co/storage/v1/object/public/workout-proof/${USER_ID}/${WORKOUT_ID}.mp4`,
+      SUPABASE_URL
+    ),
+    null
+  );
+  assert.equal(
+    parseProofObjectPath(
+      `${SUPABASE_URL}/storage/v1/object/public/other-bucket/${USER_ID}/${WORKOUT_ID}.mp4`,
+      SUPABASE_URL
+    ),
+    null
+  );
+  assert.equal(parseProofObjectPath("not a URL", SUPABASE_URL), null);
+  assert.equal(
+    parseProofObjectPath(
+      `${SUPABASE_URL}/storage/v1/object/public/workout-proof/%E0%A4%A`,
+      SUPABASE_URL
+    ),
+    null
+  );
+});
+
+test("chooseSourceObject selects a video and ignores thumbnails and images", () => {
+  assert.equal(
+    chooseSourceObject(
+      [
+        { name: `${WORKOUT_ID}_thumb.jpg` },
+        { name: `${WORKOUT_ID}.jpg` },
+        { name: `${WORKOUT_ID}.mp4` },
+        { name: `${OTHER_WORKOUT_ID}.mov` }
+      ],
+      WORKOUT_ID
+    ),
+    `${WORKOUT_ID}.mp4`
+  );
+  assert.equal(chooseSourceObject([{ name: `${WORKOUT_ID}.jpg` }], WORKOUT_ID), null);
+});
+
+test("sourceBelongsToWorkout rejects cross-user and cross-workout paths", () => {
+  assert.equal(
+    sourceBelongsToWorkout(`${USER_ID}/${WORKOUT_ID}.mp4`, USER_ID, WORKOUT_ID),
+    true
+  );
+  assert.equal(
+    sourceBelongsToWorkout(`${USER_ID}/${OTHER_WORKOUT_ID}.mp4`, USER_ID, WORKOUT_ID),
+    false
+  );
+  assert.equal(
+    sourceBelongsToWorkout(
+      `11111111-1111-4111-8111-111111111111/${WORKOUT_ID}.mp4`,
+      USER_ID,
+      WORKOUT_ID
+    ),
+    false
+  );
+});
+
+test("validateStagingUrl only accepts the configured HTTPS project", () => {
+  assert.equal(
+    validateStagingUrl(
+      "https://upwcpcjjfggdcmizgbka.supabase.co/",
+      "upwcpcjjfggdcmizgbka"
+    ),
+    "https://upwcpcjjfggdcmizgbka.supabase.co"
+  );
+  assert.throws(
+    () =>
+      validateStagingUrl(
+        "https://hgomsmhsybrxjdxbgkjy.supabase.co",
+        "upwcpcjjfggdcmizgbka"
+      ),
+    /Refusing to run/
+  );
+  assert.throws(
+    () =>
+      validateStagingUrl(
+        "http://upwcpcjjfggdcmizgbka.supabase.co",
+        "upwcpcjjfggdcmizgbka"
+      ),
+    /Refusing to run/
+  );
+});
+
+test(
+  "extractVideoFrame creates a non-empty JPEG when ffmpeg is available",
+  { skip: spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status !== 0 },
+  async () => {
+    const directory = await mkdtemp(join(tmpdir(), "kruxt-proof-thumb-test-"));
+    const videoFile = join(directory, "sample.mp4");
+    const thumbnailFile = join(directory, "thumbnail.jpg");
+
+    try {
+      const generated = spawnSync(
+        "ffmpeg",
+        [
+          "-hide_banner",
+          "-loglevel",
+          "error",
+          "-y",
+          "-f",
+          "lavfi",
+          "-i",
+          "color=c=0x22d3ee:s=320x180:d=1",
+          "-pix_fmt",
+          "yuv420p",
+          videoFile
+        ],
+        { encoding: "utf8" }
+      );
+      assert.equal(generated.status, 0, generated.stderr);
+
+      assert.equal(
+        await extractVideoFrame({
+          sourceFile: videoFile,
+          outputFile: thumbnailFile,
+          frameSeconds: 0.5,
+          spawnProcess: spawn
+        }),
+        0.5
+      );
+
+      const thumbnail = await readFile(thumbnailFile);
+      assert.ok(thumbnail.byteLength > 100);
+      assert.equal(thumbnail[0], 0xff);
+      assert.equal(thumbnail[1], 0xd8);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+);


### PR DESCRIPTION
## What changed

- add a bounded, resumable Node backfill for legacy video proofs missing poster thumbnails
- extract poster JPEGs with ffmpeg, upload them using the existing `<userId>/<workoutId>_thumb.jpg` convention, and conditionally update `workouts`
- add a manual staging-only GitHub Actions workflow with dry-run default and `BACKFILL` write confirmation
- support modern `sb_secret_...` keys through the `apikey` header, with legacy service-role JWT compatibility
- add focused safety/frame-extraction tests and an operator runbook

## Safety

- hard-locks execution to staging project `upwcpcjjfggdcmizgbka`
- rejects cross-user/cross-workout storage paths
- rejects publishable or malformed privileged keys
- reuses existing thumbnail objects and updates rows only while the thumbnail column is null
- requires explicitly configured staging credentials; production credentials are refused

## Validation

- `corepack pnpm@10.6.5 db:test` (11/11 tests pass, including real ffmpeg extraction)
- `corepack pnpm@10.6.5 --filter @kruxt/db test`
- `node --check packages/db/scripts/backfill-video-proof-thumbnails.mjs`
- `git diff --check`
- GitHub Actions validation and all three Vercel previews are green
- read-only staging verification: 0 video proofs and 0 objects currently require mutation

The permanent worktree intentionally has no `node_modules` to preserve disk space, so dependency-heavy monorepo lint/typecheck/test are delegated to cloud CI. No schema migration was added, so DB type regeneration is not required.

Before the manual workflow can run, configure `STAGING_SUPABASE_URL` and `STAGING_SUPABASE_SECRET_KEY` in repository Actions secrets. The legacy `STAGING_SUPABASE_SERVICE_ROLE_KEY` remains supported.

Closes #87

— Codex